### PR TITLE
Add basic cli `strong-studio` and remove explorer

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+var path = require('path');
+var studio = require('../server/server');
+var DEFAULT_STUDIO_HOST = 'localhost';
+var STUDIO_RUNNING_MSG = 
+exports.STUDIO_RUNNING_MSG = 'Your studio is running here:';
+var argv = getArgv();
+var pathArg = argv[0];
+var WORKSPACE_DIR = process.cwd();
+
+if(pathArg) {
+  WORKSPACE_DIR = path.join(WORKSPACE_DIR, pathArg);
+}
+
+process.env.WORKSPACE_DIR = process.env.WORKSPACE_DIR || WORKSPACE_DIR;
+
+var server = studio.listen(0, function(err) {
+  if(err) {
+    console.error('could not start studio!');
+    console.error(err);
+  }
+
+  console.log('%s http://%s:%s',
+    STUDIO_RUNNING_MSG, DEFAULT_STUDIO_HOST,
+    server.address().port);
+});
+
+function getArgv() {
+  var argv = process.argv.splice(); // copy
+  argv.shift(); // remove command
+  return argv;
+}

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "main": "app.js",
   "bin": {
-    "strongloop-api-studio": "server/server.js"
+    "strong-studio": "bin/cli.js"
   },
   "scripts": {
     "test": "gulp test",


### PR DESCRIPTION
/to @seanbrookes 

This adds the ability to start the studio using the command `strong-studio`. I'm going to move the test from `strongloop/strongloop/feature/studio` in a separate PR.

You can test this but running `npm link` and then in a loopback project `strong-studio`.

This also removes the prototype explorer, which was making requests to endpoints that did not exist.
