### PR TITLE
Listen on env.PORT when specified, exit when listen failed

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -20,6 +20,7 @@ var server = studio.listen(port, function(err) {
   if(err) {
     console.error('could not start studio!');
     console.error(err);
+    process.exit(1);
   }
 
   console.log('%s http://%s:%s',


### PR DESCRIPTION
I find it annoying that the studio listens on a different port on every restart, as I can't simply reload the browser tab to get the new GUI. The first commit adds an option to specify the port using an environmental variable `PORT`, which is btw a well-supported feature in vanilla loopback apps.

The second commit fixes a bug in the error handling code.

/to @ritch please review
