### PR TITLE
Fix creating new datasource from left sidebar

### DIFF
--- a/client/www/scripts/modules/app/app.controllers.js
+++ b/client/www/scripts/modules/app/app.controllers.js
@@ -389,9 +389,10 @@ app.controller('StudioController', [
      *
      *
      * */
-    $scope.createDatasourceViewRequest = function() {
+    $scope.createDatasourceViewRequest = function(initialData) {
       $scope.instanceType = 'datasource';
-      $scope.activeInstance = DataSourceService.createNewDatasourceInstance();
+      $scope.activeInstance =
+        DataSourceService.createNewDatasourceInstance(initialData);
       $scope.openInstanceRefs = IAService.getOpenInstanceRefs();
       $scope.clearSelectedInstances();
       IAService.showInstanceView();

--- a/client/www/scripts/modules/datasource/datasource.react.js
+++ b/client/www/scripts/modules/datasource/datasource.react.js
@@ -84,11 +84,12 @@ var DatasourceEditorView = (DatasourceEditorView = React).createClass({
               data-name="connector"
               name="connector" >
               <option value="">choose</option>
-              <option value="loopback-connector-oracle">Oracle</option>
-              <option value="loopback-connector-mssql">Microsoft SQL</option>
-              <option value="loopback-connector-mysql">MySQL</option>
-              <option value="loopback-connector-postgresql">PostgreSQL</option>
-              <option value="loopback-connector-mongodb">MongoDB</option>
+              <option value="memory">In-Memory</option>
+              <option value="oracle">Oracle</option>
+              <option value="mssql">MS SQL</option>
+              <option value="mysql">MySQL</option>
+              <option value="postgresql">PostgreSQL</option>
+              <option value="mongodb">MongoDB</option>
             </select>
           </div>
           <div className="form-group">

--- a/client/www/scripts/modules/datasource/datasource.services.js
+++ b/client/www/scripts/modules/datasource/datasource.services.js
@@ -8,7 +8,7 @@ Datasource.service('DataSourceService', [
     var svc = {};
     //  var deferred = $q.defer();
     svc.getDiscoverableDatasourceConnectors = function() {
-      return ['loopback-connector-mssql', 'loopback-connector-oracle', 'loopback-connector-mysql', 'loopback-connector-postgresql']
+      return ['mssql', 'oracle', 'mysql', 'postgresql'];
     };
 
     svc.getAllDatasources = function() {
@@ -142,7 +142,7 @@ Datasource.service('DataSourceService', [
       window.localStorage.setItem('ApiDatasources', JSON.stringify(currentDatasources));
       return datasourceDefObj;
     };
-    svc.createNewDatasourceInstance = function() {
+    svc.createNewDatasourceInstance = function(initialData) {
       //var openInstanceRefs = IAService.getOpenInstanceRefs();
       var openInstanceRefs = AppStorageService.getItem('openInstanceRefs');
       if (!openInstanceRefs) {
@@ -154,6 +154,8 @@ Datasource.service('DataSourceService', [
         facetName: CONST.NEW_DATASOURCE_FACET_NAME,
         type: CONST.DATASOURCE_TYPE
       };
+      angular.extend(defaultDatasourceSchema, initialData);
+
       var doesNewDatasourceExist = false;
       for (var i = 0;i < openInstanceRefs.length;i++) {
         if (openInstanceRefs[i].name === CONST.NEW_DATASOURCE_NAME) {

--- a/client/www/scripts/modules/ia/ia.react.js
+++ b/client/www/scripts/modules/ia/ia.react.js
@@ -322,8 +322,15 @@ var IAMainControls = (IAMainControls = React).createClass({
         else {
           val = event.target.parentElement.attributes['data-type'].value;
         }
+
+        var connector = event.target.attributes['data-name'] ?
+          event.target.attributes['data-name'].value :
+          event.target.parentElement.attributes['data-name'].value;
+
         scope.$apply(function() {
-          scope.createDatasourceViewRequest();
+          scope.createDatasourceViewRequest({
+            connector: connector
+          });
         });
       }
     };
@@ -388,7 +395,7 @@ var IAMainControls = (IAMainControls = React).createClass({
                 title="mssql connector">
                   <span className="glyphicon glyphicon-cloud"></span>
               </button>
-              <div className="ds-type-name">MsSQL</div>
+              <div className="ds-type-name">MS SQL</div>
             </div>
             <div data-ui-type="cell">
               <button onClick={addNewInstanceRequest}
@@ -404,8 +411,8 @@ var IAMainControls = (IAMainControls = React).createClass({
               <button onClick={addNewInstanceRequest}
                 data-type="datasource"
                 className="btn btn-default btn-control-ds"
-                data-name="postgres"
-                title="postgres connector">
+                data-name="postgresql"
+                title="postgresql connector">
                   <span className="glyphicon glyphicon-cloud"></span>
               </button>
               <div className="ds-type-name">Postgres</div>


### PR DESCRIPTION
- Use short connector names:
  `mysql` instead of `loopback-connector-mysql`
- Add "In-Memory" connector to the list of databases. The "db"
  datasource created by `yo loopback` is using this connector.
- Modify `createNewDatasourceInstance` to accept an object with initial
  datasource configuration. Modify the code behind sidebar buttons to
  pre-fill the connector when creating a new datasource

Close #48.

/to @ritch or @seanbrookes please review
