### PR TITLE
server: add API explorer

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -1,10 +1,15 @@
 var express = require('express');
 var path = require('path');
-var app = module.exports = express();
 var workspace = require('loopback-workspace');
+var explorer = require('loopback-explorer');
+
+var app = module.exports = express();
 
 // REST APIs
 app.use('/workspace', workspace);
+
+// API explorer
+app.use('/explorer', explorer(workspace, { basePath: '/workspace/api' }));
 
 // static files
 app.use(express.static(path.join(__dirname, '../client/www')));


### PR DESCRIPTION
The explorer provided by loopback-workspace does not work when the
workspace app is mounted at a sub-path. The solution is to mount
a new explorer instance configured with the correct API path.

/to @ritch please review
/to @seanbrookes FYI, you may find it useful
