### PR TITLE
Fix explorer integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,10 +20,6 @@
     "loopback-workspace": "strongloop/loopback-workspace",
     "request": "^2.34.0"
   },
-  "optionalDependencies": {
-    "loopback-explorer": "~1.1.0",
-    "loopback-push-notification": "~1.2.0"
-  },
   "description": "A gui for working with the LoopBack framework",
   "devDependencies": {
     "chai": "^1.9.1",
@@ -34,6 +30,7 @@
     "gulp-minify-html": "^0.1.3",
     "gulp-spawn-mocha": "^0.1.7-beta.3",
     "jshint-stylish": "^0.4.0",
+    "loopback-explorer": "^1.2.9",
     "mocha": "^1.21.4",
     "protractor": "^0.22.0",
     "run-sequence": "^0.3.6",

--- a/server/server.js
+++ b/server/server.js
@@ -8,8 +8,12 @@ var app = module.exports = express();
 // REST APIs
 app.use('/workspace', workspace);
 
-// API explorer
-app.use('/explorer', explorer(workspace, { basePath: '/workspace/api' }));
+try {
+  // API explorer
+  app.use('/explorer', explorer(workspace, { basePath: '/workspace/api' }));
+} catch(err) {
+  // silently ignore the error, the explorer is not available in "production"
+}
 
 // static files
 app.use(express.static(path.join(__dirname, '../client/www')));


### PR DESCRIPTION
- Upgrade explorer to v1.2, as v1.1 is not compatible with loopback 2.x
- Make the explorer a devDependency
- Modify server.js to handle the case when the explorer cannot be
  loaded.

Close #85

/to @ritch please review
/cc @seanbrookes @altsang 
