### PR TITLE
Rework testDataSourceConnection

### DIFF
--- a/client/www/scripts/modules/datasource/datasource.services.js
+++ b/client/www/scripts/modules/datasource/datasource.services.js
@@ -144,22 +144,17 @@ Datasource.service('DataSourceService', [
 
       return deferred.promise;
     };
-    svc.testDataSourceConnection = function(config) {
-      if (!config.connector) {
-        return $q.reject('Select a connector first.');
-      }
-
+    svc.testDataSourceConnection = function(dsId) {
       var deferred = $q.defer();
 
-      DataSourceDefinition.testConnection({}, config,
+      DataSourceDefinition.prototype$testConnection({ id: dsId },
         function(response) {
           deferred.resolve(response);
         },
         function(response) {
-          var msg = response.data && response.data.error &&
-            response.data.error.message;
-          msg = msg || 'Unexpected error ' + response.status;
-          deferred.reject(msg);
+          var error = response.data && response.data.error ||
+            new Error('Unexpected error ' + response.status);
+          deferred.reject(error);
         }
       );
 

--- a/examples/empty/package.json
+++ b/examples/empty/package.json
@@ -10,7 +10,7 @@
     "errorhandler": "^1.1.1",
     "loopback": "^2.0.0",
     "loopback-boot": "^2.0.0",
-    "loopback-datasource-juggler": "^2.0.0",
+    "loopback-datasource-juggler": "^2.6.1",
     "serve-favicon": "^2.0.1"
   },
   "optionalDependencies": {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,6 +1,7 @@
 var fs = require('fs');
 var path = require('path');
 var gulp = require('gulp');
+var install = require('gulp-install');
 var jshint = require('gulp-jshint');
 var less = require('gulp-less');
 var mocha = require('gulp-spawn-mocha');
@@ -8,7 +9,7 @@ var runSequence = require('run-sequence');
 
 gulp.task('default', ['build', 'test']);
 
-gulp.task('build', ['build-less', 'build-version']);
+gulp.task('build', ['build-less', 'build-version', 'install-example-modules']);
 
 gulp.task('build-less', function(){
   return gulp.src('client/less/style.less')
@@ -28,6 +29,11 @@ gulp.task('build-version', function(callback) {
      'client', 'www', 'scripts', 'version.js');
 
   fs.writeFile(filepath, content, 'utf-8', callback);
+});
+
+gulp.task('install-example-modules', function() {
+  return gulp.src('examples/**/package.json')
+    .pipe(install({ production: true }));
 });
 
 gulp.task('test', ['build'], function(callback) {

--- a/package.json
+++ b/package.json
@@ -12,11 +12,6 @@
   },
   "dependencies": {
     "express": "~4.8.4",
-    "loopback-connector-mongodb": "^1.4.1",
-    "loopback-connector-mssql": "^1.1.0",
-    "loopback-connector-mysql": "^1.4.2",
-    "loopback-connector-oracle": "^1.4.1",
-    "loopback-connector-postgresql": "^1.1.1",
     "loopback-workspace": "strongloop/loopback-workspace",
     "request": "^2.34.0"
   },
@@ -25,6 +20,7 @@
     "chai": "^1.9.1",
     "gulp": "^3.6.2",
     "gulp-changed": "^0.3.0",
+    "gulp-install": "^0.2.0",
     "gulp-jshint": "^1.8.4",
     "gulp-less": "^1.3.3",
     "gulp-minify-html": "^0.1.3",


### PR DESCRIPTION
- Always save the datasource before running the test.
- Use `DataSource.prototype$testConnection` which runs the test
  in a new node process in the workspace directory
- Remove loopback connectors from Studio dependencies, they are no
  longer needed
- Add a build step to install packages in all example projects.

Depends on https://github.com/strongloop/loopback-workspace/pull/124
Closes #109 

/to @ritch or @seanbrookes please review
/cc @altsang 
