### PR TITLE
Fix the list of available connectors

### DIFF
--- a/client/www/scripts/modules/datasource/datasource.react.js
+++ b/client/www/scripts/modules/datasource/datasource.react.js
@@ -168,11 +168,12 @@ var DatasourceEditorView = (DatasourceEditorView = React).createClass({
                     data-name="connector"
                     name="connector" >
                       <option value="">choose</option>
-                      <option value="loopback-connector-oracle">Oracle</option>
-                      <option value="loopback-connector-mssql">MsSQL</option>
-                      <option value="loopback-connector-mysql">MySQL</option>
-                      <option value="loopback-connector-postgres">Postgres</option>
-                      <option value="loopback-connector-mongodb">Mongo DB</option>
+                      <option value="memory">In-Memory</option>
+                      <option value="oracle">Oracle</option>
+                      <option value="mssql">MS SQL</option>
+                      <option value="mysql">MySQL</option>
+                      <option value="postgresql">PostgreSQL</option>
+                      <option value="mongodb">MongoDB</option>
                     </select>
                   </div>
                 </div>


### PR DESCRIPTION
- Add `memory` connector to the list of options
- Use short module names
  (`mysql` instead of `loopback-connector-mysql`)
- Fix the PostgreSQL item (`postgresql` instead of `postgres`)
- Use more common abbreviation `MS SQL` instead of less common `MsSQL`
- Replace `Mongo DB` with the official spelling `MongoDB`.

This fixes an unintentional revert introduced by #95.

/to @seanbrookes @ritch please review
/cc @altsang 
