### PR TITLE
Use the updated ModelConfig on model create

### DIFF
--- a/client/www/scripts/modules/model/model.services.js
+++ b/client/www/scripts/modules/model/model.services.js
@@ -25,8 +25,9 @@ Model.service('ModelService', [
             },
             config.config);
 
-            ModelConfig.create(modelConfig,
+            modelConfig = ModelConfig.create(modelConfig,
               function() {
+                setModelConfig(response, modelConfig);
                 deferred.resolve(response);
               },
               function(response) {


### PR DESCRIPTION
When a new ModelDefinition and a new ModelConfig were created,
the ModelConfig returned by the server must be stored in the
ModelDefinition returned by the server.

Before this change, the view would crash when accessing
`definition.config.dataSource`, because the `config` property was not
defined.

This is related to #126.

/to @seanbrookes @ritch please review
/cc @altsang 
