### PR TITLE
Fix ModelConfig query on data-source rename

### DIFF
--- a/client/www/scripts/modules/datasource/datasource.services.js
+++ b/client/www/scripts/modules/datasource/datasource.services.js
@@ -117,7 +117,7 @@ Datasource.service('DataSourceService', [
           updatedDefinition.$promise
             .then(function updateRelatedModelConfigs() {
               var modelConfigs = ModelConfig.find({
-                where: { dataSource: oldName }
+                filter: { where: { dataSource: oldName } }
               });
 
               return modelConfigs.$promise.then(function updateModelConfig() {


### PR DESCRIPTION
Before this change, all models were reconfigured to use the new renamed datasource.

This commit fixes the request to correctly specify the `filter.where` parameter.

Close #138 

The patch is trivial, code review is IMHO not necessary.

/cc @seanbrookes @ritch @altsang 
