### PR TITLE
Fix `gulp test-client-integration`

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -73,7 +73,8 @@ gulp.task('test-client-integration', function(callback) {
       'node_modules/.bin/karma',
       'start',
       '--single-run',
-      '--browsers PhantomJS',
+      '--browsers',
+      'PhantomJS',
       'client/test/integration/karma.integration.js',
     ],
     {


### PR DESCRIPTION
Fix karma command-line arguments, split `--browsers PhantomJS` into two arguments.

/cc @ritch @seanbrookes 
