### PR TITLE
Fix migrate button incorrectly disabled

### DIFF
--- a/client/www/scripts/modules/app/app.controllers.js
+++ b/client/www/scripts/modules/app/app.controllers.js
@@ -351,17 +351,18 @@ app.controller('StudioController', [
       }
 
       DataSourceDefinition.findOne({
-        name: config.dataSource,
-        facet: CONST.APP_FACET
+        filter: {
+          where: {
+          name: config.dataSource,
+          facetName: CONST.APP_FACET
+          }
+        }
       },
       function(dataSourceDef) {
-        console.log(CONST);
         var connector = dataSourceDef && dataSourceDef.connector;
         var connectorIsSupported = connector
           && CONST.CONNECTORS_SUPPORTING_MIGRATE
           .indexOf(connector.toLowerCase()) > -1;
-
-          console.log('connectorIsSupported', connectorIsSupported);
 
         deferred.resolve(dataSourceDef && connectorIsSupported);
       });
@@ -374,8 +375,12 @@ app.controller('StudioController', [
       var promise = deferred.promise;
 
       return DataSourceDefinition.findOne({
-        name: config.dataSource,
-        facet: CONST.APP_FACET
+        filter: {
+          where: {
+          name: config.dataSource,
+          facetName: CONST.APP_FACET
+          }
+        }
       })
       .$promise
       .then(function(dataSourceDef) {


### PR DESCRIPTION
@altsang @seanbrookes 

Before, I was using the wrong syntax to find the datasource... this patch uses the correct query and now correctly shows the migrate button as well as creates tables in mysql when run.
