### PR TITLE
client: use `modelPropertyTypes` in model form

### DIFF
--- a/client/test/integration/spec/property/property.services.ispec.js
+++ b/client/test/integration/spec/property/property.services.ispec.js
@@ -1,0 +1,25 @@
+describe('modelPropertyTypes', function() {
+  var modelPropertyTypes;
+
+  beforeEach(function() {
+    return inject(function(_modelPropertyTypes_) {
+      modelPropertyTypes = _modelPropertyTypes_;
+      return modelPropertyTypes.$promise;
+    });
+  });
+
+  it('contains all core types', function() {
+    console.log('modelPropertyTypes', modelPropertyTypes);
+    expect(modelPropertyTypes).to.include.members([
+      'string',
+      'array',
+      'buffer',
+      'date',
+      'geopoint',
+      'number',
+      'boolean',
+      'object',
+      'any'
+    ]);
+  });
+});

--- a/client/www/scripts/modules/app/app.module.js
+++ b/client/www/scripts/modules/app/app.module.js
@@ -77,7 +77,19 @@ app.config([
       state('studio', {
         url: '/studio',
         templateUrl: './scripts/modules/app/templates/studio.main.html',
-        controller: 'StudioController'
+        controller: 'StudioController',
+        resolve: {
+          // Wait for all metadata requests to finish
+          'studioMetadataResults': [
+            'modelPropertyTypes',
+            '$q',
+            function waitForAllStudioMetadata(modelPropertyTypes, $q) {
+              return $q.all([
+                modelPropertyTypes.$promise
+              ]);
+            }
+          ]
+        }
       })
       .state('landing', {
         url: '/landing',

--- a/client/www/scripts/modules/model/model.directives.js
+++ b/client/www/scripts/modules/model/model.directives.js
@@ -48,7 +48,8 @@ Model.directive('modelBaseEditor',[
  *
  * */
 Model.directive('modelPropertiesEditor',[
-  function() {
+  'modelPropertyTypes',
+  function(modelPropertyTypes) {
     return {
       controller: function($scope, growl) {
         $scope.earlyNewPropertyWarning = function() {
@@ -58,6 +59,7 @@ Model.directive('modelPropertiesEditor',[
       link: function(scope, el, attrs) {
 
         scope.isModelInstancePropertiesActive = true;
+        scope.modelPropertyTypes = modelPropertyTypes;
 
         function renderComp() {
           if (!scope.properties) {

--- a/client/www/scripts/modules/model/model.react.js
+++ b/client/www/scripts/modules/model/model.react.js
@@ -607,7 +607,7 @@ var DataTypeSelect = (DataTypeSelect = React).createClass({
 
     var val = that.state.modelProperty.type.toLowerCase();
 
-    var dataTypes = ['string','array','buffer','date','geopoint','number','boolean','object','any'];
+    var dataTypes = this.props.scope.modelPropertyTypes;
 
     var options = dataTypes.map(function(type) {
       return (<option value={type}>{type}</option>)

--- a/client/www/scripts/modules/property/property.services.js
+++ b/client/www/scripts/modules/property/property.services.js
@@ -89,3 +89,40 @@ Property.service('PropertyService', [
     return svc;
   }
 ]);
+
+/**
+ * @ngdoc factory
+ * @name Property.modelPropertyTypes
+ * @kind array
+ * @description
+ * A list of LoopBack types that can be used in model properties.
+ */
+Property.factory('modelPropertyTypes', [
+  'ModelProperty',
+  function modelPropertyTypesFactory(ModelProperty) {
+    var list = ModelProperty.getAvailableTypes();
+
+    var result = [];
+    result.$resolved = list.$resolved;
+    result.$promise = list.$promise.then(function() {
+      // Angular converts each string to a Resource object
+      // E.g. { 0: 'S', 1: 't', 2: 'r', 3: 'i', 4: 'n', 5: 'g' }
+      // We need to convert it back to string
+      list.forEach(function(res) {
+        var indices = Object.keys(res)
+          .filter(function isIndex(ix) { return /^[0-9]+$/.test(ix); })
+          .map(function convertToNumber(ix) { return +ix; });
+        indices.sort();
+
+        var str = indices.reduce(function(acc, val) {
+          return acc + res[val];
+        }, '');
+        result.push(str);
+      });
+      result.$resolved = true;
+      return result;
+    });
+
+    return result;
+  }
+]);


### PR DESCRIPTION
Implement `modelPropertyTypes` factory that returns a cached array
of all property types supported by the Studio.

Configure Angular routing so that the `/studio` route waits until
the `modelPropertyTypes` is loaded.

Rework `modelPropertiesEditor` and `DataTypeSelect` to get the list
of types from `modelPropertyTypes`.

Close #41 

This patch is based on #262 with the following improvements:
- `modelPropertyTypes` has a name starting with a lower case letter and is registered as a `factory` (not `service`).
  This is to indicate that `modelPropertyTypes` is a value object, not a class instance.
  (See [Providers > Conclusion](https://code.angularjs.org/1.2.25/docs/guide/providers#conclusion) in Angular docs for more details.)
- `modelPropertiesTypes` is injected into the `modelPropertiesEditor` directive, which stores the value on the `scope` for the react component. No new DI arguments are added to any controller. 
  
  I can imagine passing `modelPropertiesTypes` directly to React component as part of `props`, however that would require a bit more work to pass this new property down the component chain (`ModelPropertiesEditor` > `ModelPropertyRowDetail` > `DataTypeSelect`) It seems to me the extra code is not worth it.

/to @seanbrookes Please review. 
/cc @ritch @anthonyettinger 
