### PR TITLE
client/explorer: use host from project config

### DIFF
--- a/client/test/integration/spec/explorer/explorer.services.ispec.js
+++ b/client/test/integration/spec/explorer/explorer.services.ispec.js
@@ -42,13 +42,17 @@ describe('ExplorerService', function() {
   });
 
   it('builds correct swagger URL', function() {
-    return given.facetConfig('server', { restApiRoot: '/rest', port: 3030 })
+    return given.facetConfig('server', {
+      restApiRoot: '/rest',
+      host: '127.0.0.1',
+      port: 3030
+    })
       .then(given.targetAppIsRunning)
       .then(ExplorerService.getSwaggerResources.bind(ExplorerService))
       .catch(throwHttpError)
       .then(function(swagger) {
         expect(swagger).to.have.property('length', 1);
-        expect(swagger[0].basePath).to.equal('http://localhost:3030/rest');
+        expect(swagger[0].basePath).to.equal('http://127.0.0.1:3030/rest');
       });
   });
 


### PR DESCRIPTION
This is a follow-up for #269.

Modify `ExplorerService.getSwaggerResources` to use the hostname configured in project's `server/config.json` when building a URL for accessing the swagger metadata.

/to @seanbrookes please review
/cc @ritch @anthonyettinger 
