### PR TITLE
package: use workspace from npmjs.org

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "debug": "^2.0.0",
     "express": "~4.8.4",
-    "loopback-workspace": "strongloop/loopback-workspace",
+    "loopback-workspace": "^3.3.0",
     "opener": "~1.4.0",
     "request": "^2.34.0",
     "ws": "^0.4.32"


### PR DESCRIPTION
Replace github URL with a semver spec `^3.3.0`.

This pull request changes few things:
- Studio will not upgrade workspace after a breaking change (i.e. `v4.x`), which is a good thing.
- Studio users will get a version from npm with a unique version number (e.g. `3.3.0`). At the moment, npm will install the latest github commit which usually has the same version number as the last released version (e.g. `3.3.0`), but adds some changes on top of that without changing the version number. As a result, it may be difficult to figure out what exact version users are running.
- We have to release workspace changes to npm before they are picked up by the Studio. It should not add much overhead, since the amount of changes in workspace seems to be low these days.

/to @ritch please review
/cc @altsang @seanbrookes @anthonyettinger 
