### PR TITLE
hide app selector on un-related pages.

### DIFF
--- a/client/www/scripts/modules/app/app.controllers.js
+++ b/client/www/scripts/modules/app/app.controllers.js
@@ -1,11 +1,7 @@
 // Copyright StrongLoop 2014
 app.controller('SuiteController', ['$scope', 'LandingService', 'ProfileService', function($scope, LandingService, ProfileService){
   $scope.suiteIA = {
-    apps: [],
-    selectedApp: {
-      id: 'none',
-      name: 'Select Module'
-    }
+    apps: []
   };
 
   $scope.isAuthUser = function(){

--- a/client/www/scripts/modules/landing/landing.controllers.js
+++ b/client/www/scripts/modules/landing/landing.controllers.js
@@ -3,10 +3,6 @@ Landing.controller('LandingController', [
   '$scope',
   'LandingService',
   function ($scope, LandingService) {
-    $scope.suiteIA.selectedApp =  {
-      id: 'none',
-      name: 'Select Module'
-    };
 
     LandingService.getApps()
       .then(function (data) {

--- a/client/www/scripts/modules/landing/landing.directives.js
+++ b/client/www/scripts/modules/landing/landing.directives.js
@@ -21,7 +21,7 @@ Landing.directive('slAppSelector', [
         $scope.selected = $scope.suiteIA.selectedApp;
 
         $scope.isMenuVisible = function(){
-          return $scope.isAuthUser();
+          return $scope.isAuthUser() && $scope.suiteIA.selectedApp;
         };
 
       },


### PR DESCRIPTION
should only be visible on api composer and profiler pages. #294 

@seanbrookes please review
