### PR TITLE
Tell CI not to run mocha directly

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "scripts": {
     "prepublish": "gulp build",
-    "test": "gulp test",
+    "test": "gulp mocha-and-karma",
     "start": "node app.js"
   },
   "dependencies": {


### PR DESCRIPTION
Our CI runner sees the mocha deps and assumes it should run mocha
directly. Using an alias like this tells CI to just run 'npm test' and
let the project take care of generating the necessary artifacts.

As described in:
https://github.com/strongloop/strong-studio/pull/296#issuecomment-56727158
