### PR TITLE
trigger resize event to work around data glitch on discovery step1

### DIFF
--- a/client/www/scripts/modules/discovery/discovery.controllers.js
+++ b/client/www/scripts/modules/discovery/discovery.controllers.js
@@ -33,6 +33,9 @@ Discovery.controller('DiscoveryMainController', [
           $scope.schemaSrcTables = schemaData;  // trigger the grid display
           $scope.isDsTableGridVisible = true;
           $scope.isDsTablesLoadingIndicatorVisible = false;
+
+          //todo: work around for step1 not showing data grid
+          $(window).trigger('resize');
         });
     }
 


### PR DESCRIPTION
work around to show data on discovery step 1. 

its unclear what the real problem is, I suspect upgrading the library to something newer may solve the problem.
#306
