### PR TITLE
[0.2.x] client: ignore readonly models

### DIFF
--- a/client/test/integration/spec/model/model.services.ispec.js
+++ b/client/test/integration/spec/model/model.services.ispec.js
@@ -17,6 +17,18 @@ describe('ModelService', function() {
 
   beforeEach(given.emptyWorkspace);
 
+  describe('.getAllModelInstances()', function() {
+    it('ignores readonly models', function() {
+      // A temporary test until this task is implemented:
+      // https://github.com/strongloop/strong-studio/issues/431
+      return ModelService.getAllModelInstances()
+        .then(function(instances) {
+          var names = instances.map(function(i) { return i.name; });
+          expect(names).to.not.include('RoleMapping');
+        });
+    });
+  });
+
   describe('.createModelInstance()', function() {
     it('removes internal Studio properties', function() {
       var instance = given.modelInstance();

--- a/client/test/integration/test-server.js
+++ b/client/test/integration/test-server.js
@@ -40,6 +40,9 @@ studio.post('/reset', function(req, res, next) {
         async.eachSeries(
           list,
           function(instance, cb) {
+            if (instance.readonly) {
+              return cb();
+            }
             entity.removeById(instance.id, cb);
           },
           next);

--- a/client/www/scripts/modules/model/model.services.js
+++ b/client/www/scripts/modules/model/model.services.js
@@ -153,7 +153,7 @@ Model.service('ModelService', [
             configMap[value.name] = value;
           });
 
-          ModelDefinition.find({},
+          ModelDefinition.find({ filter: { where: { readonly: false } } },
             function(response) {
 
               // add create model to this for new model

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "debug": "^2.0.0",
     "express": "~4.8.4",
-    "loopback-workspace": "^3.4.0",
+    "loopback-workspace": "^3.5.0",
     "opener": "~1.4.0",
     "request": "^2.34.0",
     "ws": "^0.4.32"


### PR DESCRIPTION
Ignore readonly loopback built-in models as the GUI is not ready to
handle them yet.

This is a back-port of #435 to resolve #450.
