### PR TITLE
Fix broken datasource tests

### DIFF
--- a/client/test/integration/helpers/given.js
+++ b/client/test/integration/helpers/given.js
@@ -1,6 +1,12 @@
 var given = {};
 
 given.emptyWorkspace = function() {
+  // Increase the timeout when run via `beforeEach(given.emptyWorkspace)`
+  // in order to support slow CI build slaves
+  if (typeof this.timeout === 'function') {
+    this.timeout(30000);
+  }
+
   return inject(function($http, $rootScope, $q, throwHttpError) {
     function reset() {
       return $http({

--- a/client/test/integration/spec/datasource/datasource.services.ispec.js
+++ b/client/test/integration/spec/datasource/datasource.services.ispec.js
@@ -15,7 +15,7 @@ describe('DataSourceService', function() {
     });
   });
 
-  //beforeEach(given.emptyWorkspace);
+  beforeEach(given.emptyWorkspace);
 
   describe('.createDataSourceInstance()', function() {
     it('removes internal Studio properties', function() {
@@ -31,10 +31,8 @@ describe('DataSourceService', function() {
           expect(created).to.have.property('definition');
           DataSourceService.getDataSourceInstanceById(created.id)
             .then(function(found) {
-              expect(found).to.have.property('config');
               expect(found).to.have.property('type');
               expect(found).to.have.property('definition');
-              expect(found.definition).to.not.have.property('config');
               expect(found.definition).to.not.have.property('type');
             });
         });
@@ -51,17 +49,15 @@ describe('DataSourceService', function() {
             expect(created).to.have.property('name');
             expect(created).to.have.property('definition');
             // setActiveInstance used to add `type` property
-            IAService.setActiveInstance(created, CONST.MODEL_TYPE);
+            IAService.setActiveInstance(created, CONST.DATASOURCE_TYPE);
 
             return DataSourceService.updateDataSourceInstance(created);
           })
           .then(function(updated) {
             DataSourceService.getDataSourceInstanceById(updated.id)
               .then(function(found) {
-                expect(found).to.have.property('config');
                 expect(found).to.have.property('type');
                 expect(found).to.have.property('definition');
-                expect(found.definition).to.not.have.property('config');
                 expect(found.definition).to.not.have.property('type');
               });
             });

--- a/client/test/integration/spec/smoke.ispec.js
+++ b/client/test/integration/spec/smoke.ispec.js
@@ -1,7 +1,5 @@
 describe('Studio', function() {
-  beforeEach(function() {
-    return given.emptyWorkspace();
-  });
+  beforeEach(given.emptyWorkspace);
 
   it('can get package definition', function() {
     return inject(function(PackageDefinition, throwHttpError) {


### PR DESCRIPTION
A follow-up for #449.
- Reenable `beforeEach(given.emptyWorkspace)`.
- Modify `given.emptyWorkspace` to increase the hook timeout
  in order to prevent timeouts on slow CI build slaves.
- Remove checks for `config` property that does not exist in
  datasources. It used to be a problem in models, I suspect the checks
  very copied over.

/to @seanbrookes please review
