### PR TITLE
Fix bug where file vs. remote isn't reseting

### DIFF
--- a/client/www/scripts/modules/common/common.directives.js
+++ b/client/www/scripts/modules/common/common.directives.js
@@ -131,6 +131,7 @@ Common.directive('slCommonPidSelector', [
           port: ''
         };
 
+        $scope.hasIframe = $attrs.iframe;
         $scope.activeProcess = null;
         $scope.showMoreMenu = false;
         $scope.isRemoteValid = false;
@@ -160,6 +161,14 @@ Common.directive('slCommonPidSelector', [
           $scope.isRemoteValid = false;
           $scope.processes = [];
           $scope.activeProcess = null;
+
+          if ( $scope.hasIframe ) {
+            var iframe = window.frames['devtools'];
+
+            if ( iframe.SL ) {
+              iframe.SL.child.profiler.slInit();
+            }
+          }
         };
 
         $scope.$watch('form.$valid', function(newVal, oldVal) {
@@ -175,6 +184,16 @@ Common.directive('slCommonPidSelector', [
           $scope.isProcessFromMore = isMoreClick;
           $log.log('active process', process);
           $scope.isRemoteValid = true;
+
+          if ( $scope.hasIframe ) {
+            var iframe = window.frames['devtools'];
+
+            if ( iframe.SL ) {
+              iframe.SL.child.profiler.slInit();
+              iframe.SL.child.profiler.setServer($scope.server);
+              iframe.SL.child.profiler.setActiveProcess(process);
+            }
+          }
         };
       }
     }

--- a/client/www/scripts/modules/profiler/profiler.directives.js
+++ b/client/www/scripts/modules/profiler/profiler.directives.js
@@ -28,16 +28,17 @@ Profiler
             }
           });
 
-          //clear out active processes and remote state when going back to file
-          $scope.resetRemoteState = function(){
-            var iframe = window.frames['devtools'];
-
-            $scope.isRemoteValid = false;
-            $scope.processes = [];
-            $scope.activeProcess = null;
-
-            iframe.SL.child.profiler.slInit();
-          };
+          //@deprecated moved to common.directives.js
+          ////clear out active processes and remote state when going back to file
+          //$scope.resetRemoteState = function(){
+          //  var iframe = window.frames['devtools'];
+          //
+          //  $scope.isRemoteValid = false;
+          //  $scope.processes = [];
+          //  $scope.activeProcess = null;
+          //
+          //  iframe.SL.child.profiler.slInit();
+          //};
 
           $scope.$watch('form.$valid', function(newVal, oldVal) {
             if ( newVal !== oldVal && !newVal ) {
@@ -45,19 +46,20 @@ Profiler
             }
           });
 
-          $scope.$watch('activeProcess', function(process, oldVal){
-            if ( !process || $scope.activeProcess && $scope.activeProcess.status !== 'Running' ) return false;
-
-            var iframe = window.frames['devtools'];
-
-            $scope.activeProcess = process;
-            $log.log('active process', process);
-            $scope.isRemoteValid = true;
-
-            iframe.SL.child.profiler.slInit();
-            iframe.SL.child.profiler.setServer($scope.server);
-            iframe.SL.child.profiler.setActiveProcess(process);
-          });
+          //@deprecated moved to common.directives.js
+          //$scope.$watch('activeProcess', function(process, oldVal){
+          //  if ( !process || $scope.activeProcess && $scope.activeProcess.status !== 'Running' ) return false;
+          //
+          //  var iframe = window.frames['devtools'];
+          //
+          //  $scope.activeProcess = process;
+          //  $log.log('active process', process);
+          //  $scope.isRemoteValid = true;
+          //
+          //  iframe.SL.child.profiler.slInit();
+          //  iframe.SL.child.profiler.setServer($scope.server);
+          //  iframe.SL.child.profiler.setActiveProcess(process);
+          //});
 
           $scope.fetchHeapFile = function(){
             if ( !$scope.activeProcess ) return;
@@ -152,12 +154,12 @@ Profiler
               });
           },
 
-            SL.parent.profiler.startCpuProfiling = function(cb){
-              $scope.startCpuProfiling()
-                .then(function(data){
-                  cb(data);
-                });
-            }
+          SL.parent.profiler.startCpuProfiling = function(cb){
+            $scope.startCpuProfiling()
+              .then(function(data){
+                cb(data);
+              });
+          }
         }
       }
     }]);

--- a/client/www/scripts/modules/profiler/templates/profiler.navbar.html
+++ b/client/www/scripts/modules/profiler/templates/profiler.navbar.html
@@ -6,6 +6,6 @@
     </div>
   </nav>
   <nav class="sl-profiler-remote" ng-show="profilerId == 'remote'">
-    <sl-common-pid-selector></sl-common-pid-selector>
+    <sl-common-pid-selector iframe="true"></sl-common-pid-selector>
   </nav>
 </div>

--- a/devtools/custom/strongloop.js
+++ b/devtools/custom/strongloop.js
@@ -52,3 +52,8 @@ SL.child.profiler = {
     document.documentElement.dispatchEvent(event);
   }
 };
+
+//initialize itself when iframe loads
+(function(){
+    SL.child.profiler.slInit();
+})();


### PR DESCRIPTION
Fix bug where file vs. remote isn't reseting
- the devtools iframe was not resetting when going back to File mode
- move logic from profiler.directive to common.directive
- add `iframe` flag to `<sl-pid-selector>`

@seanbrookes please review. Isaac found this bug, its a result of the pid-selector refactoring missing some logic needed for iframe communcation.
