### PR TITLE
Add an embeded process manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ bower_components
 /devtools/custom/strongloop.css
 *-xunit.xml
 sandbox
+client/test/integration/sandbox/
+.strong-pm

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -103,6 +103,7 @@ gulp.task('test', ['build'], function(callback) {
   runSequence(
     'jshint',
     'test-server',
+    'test-pm',
     'setup-mysql',
     'test-client-integration',
     callback);
@@ -127,6 +128,11 @@ gulp.task('jshint', function() {
 
 gulp.task('test-server', function() {
   return gulp.src('server/test/*.js', { read: false })
+    .pipe(mocha());
+});
+
+gulp.task('test-pm', function() {
+  return gulp.src('process-manager/test/*.js', { read: false })
     .pipe(mocha());
 });
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "split": "~0.3.1",
     "strong-deploy": "^1.1.0",
     "strong-pm": "^1.3.1",
-    "ws": "~0.4.32"
+    "ws": "~0.4.32",
+    "http-proxy": "^1.6.2"
   },
   "description": "A gui for working with the LoopBack framework",
   "devDependencies": {

--- a/process-manager/server.js
+++ b/process-manager/server.js
@@ -1,0 +1,49 @@
+var split = require('split');
+var express = require('express');
+var spawn = require('child_process').spawn;
+var server = express();
+var isRunning = false;
+var PORT = null;
+var pm = null;
+var httpProxy = require('http-proxy');
+var proxy = httpProxy.createProxyServer();
+
+module.exports = server;
+
+server.use(function ensureStarted(req, res, next) {
+  if(isRunning) {
+    next();
+  } else {
+    start(next);
+  }
+});
+
+server.use(function startProxy(req, res, next) {
+  req.url = req.url.replace('/process-manager', '/');
+  proxy.web(req, res, {
+    target: 'http://localhost:' + PORT
+  });
+});
+
+function start(next) {
+  var pathToPm = require.resolve('strong-pm/bin/sl-pm');
+  var args = [pathToPm, '--listen', '0'];
+  // TODO(ritch) use exec path
+  pm = spawn('node', args);
+  pm.stdout.pipe(split()).on('data', function(line) {
+    console.log(line);
+    PORT = parsePort(line);
+    if(PORT && !isRunning) {
+      isRunning = true;
+      next();
+    }
+  });
+  pm.stderr.pipe(process.stderr);
+}
+
+function parsePort(line) {
+  var match = line.match(/listen on (\d+)/);
+  if(match) {
+    return match[1];
+  }
+}

--- a/process-manager/test/process-manager.test.js
+++ b/process-manager/test/process-manager.test.js
@@ -1,0 +1,13 @@
+var processManager = require('../server');
+var request = require('supertest');
+
+describe('process-manager-proxy', function() {
+  this.timeout(10000);
+  it('should proxy requests to the underlying process-manager', function(done) {
+    request(processManager)
+      .get('/')
+      .set('accept', 'application/json')
+      .expect(200)
+      .end(done);
+  });
+});

--- a/server/server.js
+++ b/server/server.js
@@ -3,6 +3,7 @@ var path = require('path');
 var workspace = require('loopback-workspace');
 var buildDeploy = require('../build-deploy/server/server');
 var devtools = require('../devtools/server/devtools');
+var pm = require('../process-manager/server');
 
 var app = module.exports = express();
 
@@ -13,6 +14,7 @@ app.workspace = workspace;
 app.use('/workspace', workspace);
 app.use('/devtools', devtools);
 app.use('/build-deploy', buildDeploy);
+app.use('/process-manager', pm);
 
 try {
   // API explorer


### PR DESCRIPTION
This adds the `/process-manager` API. HTTP requests beginning with this URL will be proxied to the `strong-pm` instances running as a sub process.

**Note:** the first request to this URL will start the sub process... all other requests will just be proxied to the running process.

/to @anthonyettinger @seanbrookes 
/cc @kraman
