### PR TITLE
hide file button when remote default state is set

### DIFF
--- a/devtools/frontend/profiler/ProfileLauncherView.js
+++ b/devtools/frontend/profiler/ProfileLauncherView.js
@@ -76,6 +76,7 @@ WebInspector.ProfileLauncherView.prototype = {
                 this._hideCpuButtons();
             } else {
                 this._toggleFetchButtons();
+                this._showFetchButtons();
             }
         }.bind(this);
 


### PR DESCRIPTION
hide file button when remote default state is set
- default state when flopped to remote was showing wrong buttons

@seanbrookes please review
