### PR TITLE
Fix call to git deploy from strong-deploy

### DIFF
--- a/build-deploy/common/models/deployment.js
+++ b/build-deploy/common/models/deployment.js
@@ -1,5 +1,6 @@
 var performGitDeployment = require('strong-deploy/lib/git').performGitDeployment;
 var performHttpPutDeployment = require('strong-deploy/lib/put-file').performHttpPutDeployment;
+var performLocalDeployment = require('strong-deploy/lib/post-json').performLocalDeployment;
 var request = require('request');
 
 module.exports = function(Deployment) {
@@ -12,7 +13,13 @@ module.exports = function(Deployment) {
     function deploy(err){
       if ( err ) return cb(err);
 
-      if(deployment.type === 'git') {
+      if(deployment.type === 'local') {
+        // Note: I strongly recommend a `deployment.processes` of 1 for local,
+        // especially since its not configurable in the UI.
+        var cwd = process.cwd();
+        // args are: baseUrl, localdir, config, callback
+        performLocalDeployment(baseURL, cwd, '', cb);
+      } else if(deployment.type === 'git') {
         var cwd = process.cwd();
         // args are: workingDir, baseUrl, config, branch, callback
         performGitDeployment(cwd, baseURL, '', deployment.branch, cb);
@@ -23,7 +30,6 @@ module.exports = function(Deployment) {
     }
 
     function resize() {
-      //todo check status of deploy first
       request.put(baseURL + '/api/ServiceInstances/1', {
         json: true,
         body: {


### PR DESCRIPTION
Args didn't match, resulting in callback not called.

Fix strongloop/strong-pm#76

/cc @anthonyettinger @ritch @kraman 

Untested... I don't know to run this code, but it looks right, maybe @anthonyettinger can give it a whirl.
