### PR TITLE
deps: bump strong-deploy dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "request": "^2.34.0",
     "serve-favicon": "^2.1.6",
     "split": "~0.3.1",
-    "strong-deploy": "^1.0.0",
+    "strong-deploy": "^1.1.0",
     "strong-pm": "^1.3.1",
     "ws": "~0.4.32"
   },


### PR DESCRIPTION
The local-deploy feature used was published in 1.1.0, so we need to up
the minimum version to ensure a 1.0.x release isn't used if it is
already installed.
