### PR TITLE
force contextual help links to open in new window

### DIFF
--- a/build-tasks/download-help-assets.js
+++ b/build-tasks/download-help-assets.js
@@ -59,8 +59,12 @@ function resolveRelativeHrefs(html) {
 
   $('a').each(function() {
     var href = $(this).attr('href');
-    if (/^\/display/.test(href))
+
+    if (/^\/display/.test(href)) {
       $(this).attr('href', CONFLUENCE_URL_BASE + href.slice(1));
+    }
+
+    $(this).attr('target', '_new');
   });
   return $.html();
 }


### PR DESCRIPTION
force contextual help links to open in new window
- add 'target=_new' attribute to help links
