### PR TITLE
Bundle dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,23 @@
     "ws": "~0.4.32",
     "http-proxy": "^1.6.2"
   },
+  "bundledDependencies": [
+    "cookie-parser",
+    "debug",
+    "errorhandler",
+    "express",
+    "fs-extra",
+    "loopback",
+    "loopback-boot",
+    "loopback-datasource-juggler",
+    "loopback-workspace",
+    "opener",
+    "request",
+    "serve-favicon",
+    "split",
+    "ws",
+    "http-proxy"
+  ],
   "description": "A gui for working with the LoopBack framework",
   "devDependencies": {
     "async": "~0.9.0",


### PR DESCRIPTION
**NOT INTENDED FOR MERGE**

Does not bundle strong-pm and strong-deploy so that npm has the option
of deduping them with the versions installed by strongloop when
strong-arc is installed as a dependency of strongloop.

This is the most obvious solution for #451, though I don't think it is necessarily the best.