### PR TITLE
only add the internal pm host instance once - and at the end

### DIFF
--- a/client/www/scripts/modules/pm/pm.module.js
+++ b/client/www/scripts/modules/pm/pm.module.js
@@ -8,7 +8,7 @@ var PM_CONST = {
   RESTARTING_STATE: 'restarting',
   STOPPING_STATE: 'stopping',
   UNKNOWN_STATE: 'unknown',
-  LOCAL_PM_HOST_NAME: 'arc.local.pm',
+  LOCAL_PM_HOST_NAME: 'local application',
   LOCAL_PM_PORT_MASK: 9999
 };
 PM.value('PM_CONST', PM_CONST);
@@ -29,15 +29,16 @@ PM.run([
 ]);
 PM.run([
   'PMHostService',
+  'PMAppService',
   '$log',
-  function (PMHostService, $log) {
+  function (PMHostService, PMAppService) {
 
-    var defaultLocalPMHostConfig = {
-      host: PM_CONST.LOCAL_PM_HOST_NAME,
-      port: PM_CONST.LOCAL_PM_PORT_MASK
-    };
-    $log.debug('add local Arc PM host reference: ' + JSON.stringify(defaultLocalPMHostConfig));
-    return PMHostService.addPMServer(defaultLocalPMHostConfig)
+    PMAppService.isLocalApp()
+      .then(function(response) {
+        if (response === true) {
+          PMHostService.initializeInternalPMHost();
+        }
+      });
 
   }
 ]);

--- a/client/www/scripts/modules/pm/pm.services.js
+++ b/client/www/scripts/modules/pm/pm.services.js
@@ -162,6 +162,35 @@ PM.service('PMHostService', [
       window.localStorage.removeItem('pmServers');
       return [];
     };
+    svc.addLastPMServer = function(serverConfig) {
+      var updatedServers = svc.getPMServers();
+      updatedServers[updatedServers.length] = serverConfig;
+      window.localStorage.setItem('pmServers', JSON.stringify(updatedServers));
+      return updatedServers;
+
+    };
+    svc.initializeInternalPMHost = function() {
+      var defaultLocalPMHostConfig = {
+        host: PM_CONST.LOCAL_PM_HOST_NAME,
+        port: PM_CONST.LOCAL_PM_PORT_MASK
+      };
+      var isExists = false; // only inject it we need to
+      // determine whether or not to inject local pm reference
+      var currentPMHosts = svc.getPMServers();
+      if (!currentPMHosts) {
+        return svc.addPMServer(defaultLocalPMHostConfig);
+      }
+      for (var i = 0;i < currentPMHosts.length;i++) {
+        if (defaultLocalPMHostConfig.host === currentPMHosts[i].host) {
+          isExists = true;
+          break;
+        }
+      }
+      if (!isExists) {
+        // add to the end of the list
+        svc.addLastPMServer(defaultLocalPMHostConfig);
+      }
+    };
     svc.addPMServer = function(serverConfig) {
       // check the list to see if it exists
       // if it does then make it the most recent


### PR DESCRIPTION
currently the pm host selector always shows the internal host even if you were referencing a different host and refresh the page or navigate between modules - very annoying

/to: @anthonyettinger 
