### PR TITLE
fix timing issue with model/property create

### DIFF
--- a/client/www/scripts/modules/composer/composer.controllers.js
+++ b/client/www/scripts/modules/composer/composer.controllers.js
@@ -391,25 +391,38 @@ Composer.controller('ComposerMainController', [
     // create model property
     $scope.createNewModelProperty = function() {
 
+      // make sure the model has finished initializing
+      if ($scope.isCreatingModelDef) {
+        return $timeout(function() {
+          $scope.createNewModelProperty();
+        }, 35);
+      }
+
       // get model id
       var modelId = $scope.activeInstance.id;
       // should get a config (with at least name/type of property)
 
-      var propConfig = {
-        name:'propertyName' + getRandomNumber(),
-        type: 'string',
-        facetName: CONST.NEW_MODEL_FACET_NAME,
-        modelId: modelId
-      };
+      if (modelId) {
+        var propConfig = {
+          name:'propertyName' + getRandomNumber(),
+          type: 'string',
+          facetName: CONST.NEW_MODEL_FACET_NAME,
+          modelId: modelId
+        };
 
-      var newProperty = PropertyService.createModelProperty(propConfig);
-      newProperty.
-        then(function (result) {
-          growl.addSuccessMessage("property created");
-          $scope.activeInstance.properties.push(result);
-          $scope.activeModelPropertiesChanged = !$scope.activeModelPropertiesChanged;
-        }
-      );
+        var newProperty = PropertyService.createModelProperty(propConfig);
+        newProperty.
+          then(function (result) {
+            growl.addSuccessMessage("property created");
+            $scope.activeInstance.properties.push(result);
+            $scope.activeModelPropertiesChanged = !$scope.activeModelPropertiesChanged;
+          }
+        );
+      }
+      else {
+        $log.warn('create model property called without valid modelId');
+      }
+
 
     };
     function getRandomNumber() {


### PR DESCRIPTION
- if a user clicks the new property button directly
  after blurring the model name input it will create a
  race condition where the mode must exist before a
  property can be created.
- there is a property that is set during the model create
  async process indicating the model is being created
  so we are now checking that property and looping until
  it has been reset to creating=false

/to: @bajtos 
/cc: @anthonyettinger 
