### PR TITLE
add 'early preview' tag to Metrics app on landing

### DIFF
--- a/client/less/landing/landing.less
+++ b/client/less/landing/landing.less
@@ -141,9 +141,19 @@
     }
 
     .app-name {
+      position:relative;
       font-size: 1.5rem;
       color: @gray;
       margin-top: .8rem;
+
+      .early-preview {
+        position:absolute;
+        top:1.4rem;
+        right:-5.1rem;
+        color:@brand-info;
+        font-weight:800;
+        font-size:85%
+      }
     }
 
     a.app-launch {

--- a/client/less/metrics.less
+++ b/client/less/metrics.less
@@ -10,6 +10,12 @@
   [data-ui-type="cell"] {
     vertical-align: middle;
   }
+
+  .early-preview {
+    color:@brand-info;
+    font-weight:800;
+    font-size:85%
+  }
 }
 .metrics-main-container .sl-pid-selector{
   margin-left:2rem;

--- a/client/www/scripts/modules/landing/landing.directives.js
+++ b/client/www/scripts/modules/landing/landing.directives.js
@@ -1,10 +1,20 @@
 // Copyright StrongLoop 2014
 Landing.directive('slLandingApp', [
-  function () {
+  '$log',
+  function ($log) {
     return {
       restrict: "E",
       replace: true,
-      templateUrl: './scripts/modules/landing/templates/landing.app.html'
+      templateUrl: './scripts/modules/landing/templates/landing.app.html',
+      link: function(scope, el, attrs) {
+
+        // temporary while metrics is in prevew
+        if (attrs.id === 'metrics') {
+          // build a tag and add it to the a.app-name child element
+          $(el).find('a.app-name').append('<div class="early-preview">*early preview</div>');
+        }
+
+      }
     };
   }
 ]);

--- a/client/www/scripts/modules/landing/templates/landing.app.html
+++ b/client/www/scripts/modules/landing/templates/landing.app.html
@@ -1,4 +1,4 @@
-<div class="sl-app">
+<div class="sl-app" data-id="{{ app.id }}">
   <div class="app-container" ng-class="{'app-unsupported' : !app.supportsCurrentProject }" ui-sref="{{getSref(app)}}">
     <i class="app-image sl-app-icon sl-app-icon-{{app.id}}"></i>
     <i class="app-image-hover sl-app-icon sl-app-icon-{{app.id}}-hover"></i>

--- a/client/www/scripts/modules/metrics/metrics.controllers.js
+++ b/client/www/scripts/modules/metrics/metrics.controllers.js
@@ -1,5 +1,6 @@
 Metrics.controller('MetricsMainController', [
   '$scope',
+  '$state',
   '$log',
   'growl',
   '$interval',
@@ -7,7 +8,7 @@ Metrics.controller('MetricsMainController', [
   'PMPidService',
   'PMHostService',
   'ChartConfigService',
-  function($scope, $log, growl, $interval, MetricsService, PMPidService, PMHostService, ChartConfigService) {
+  function($scope, $state, $log, growl, $interval, MetricsService, PMPidService, PMHostService, ChartConfigService) {
 
     $scope.isDisplayChartValid = false; // control display of charts (transition between data sets)
     $scope.currentServerConfig = PMHostService.getLastPMServer();
@@ -262,8 +263,10 @@ Metrics.controller('MetricsMainController', [
             }
             else {
               $log.warn('getMetricsSnapShot returned no metrics');
-              growl.addWarnMessage('No metrics available.', {ttl: 2000});
-              growl.addWarnMessage('License invalid or not present. Please contact sales@strongloop.com for a valid license.', {ttl: 10000});
+              if ($state.includes('metrics')){
+                growl.addWarnMessage('No metrics available.', {ttl: 2000});
+                growl.addWarnMessage('No metrics available. Your license may be invalid or not present. Please contact sales@strongloop.com for a valid license.', {ttl: 10000});
+              }
               return;
             }
           });

--- a/client/www/scripts/modules/metrics/templates/metrics.main.html
+++ b/client/www/scripts/modules/metrics/templates/metrics.main.html
@@ -3,7 +3,7 @@
   <div sl-metrics-title class="metrics-title-container" data-ui-type="table">
     <div data-ui-type="row">
       <div data-ui-type="cell">
-        <div class="metrics-title">Metrics</div>
+        <div class="metrics-title">Metrics <span class="early-preview">*early preview</span></div>
       </div>
       <div data-ui-type="cell" class="metrics-data-point-count-col">
          <div class="metrics-header-label">Data Points: <span class="instrument-value">{{ dataPointCount }}</span></div>

--- a/client/www/scripts/modules/pm/pm.directives.js
+++ b/client/www/scripts/modules/pm/pm.directives.js
@@ -123,7 +123,6 @@ PM.directive('slPmHostForm', [
                 PMAppService.isLocalAppRunning()
                   .then(function(response) {
                     if (response.started === false) {
-                      growl.addInfoMessage('local app is not running', {ttl:700});
                       growl.addInfoMessage('starting local app ...', {ttl:1000});
                       PMAppService.startLocalApp()
                         .then(function(response) {


### PR DESCRIPTION
- temporary code to detect metrics app and add a
  tag to display 'early preview' for first iteration
- add early preview tag to metrics title
- tweaked the metrics growl messages to only
  show when metrics view is active

![screenshot](https://cloud.githubusercontent.com/assets/1140553/5436177/803945ce-8463-11e4-88b0-ed16976a9547.png)

![screenshot 1](https://cloud.githubusercontent.com/assets/1140553/5436176/8038f948-8463-11e4-820f-ab4a4e608f47.png)

/to: @bajtos 
/cc: @anthonyettinger 
