### PR TITLE
discovery: always import id and required props

### DIFF
--- a/client/less/discovery.less
+++ b/client/less/discovery.less
@@ -15,6 +15,12 @@
     text-align: center;
     font-size:175%;
 }
+
+.modal-header .growl {
+  z-index: 100;
+  font-size: 16px;
+}
+
 .modal-body {
     padding:8px 20px 20px 20px;
 }

--- a/client/www/scripts/modules/discovery/discovery.directives.js
+++ b/client/www/scripts/modules/discovery/discovery.directives.js
@@ -8,7 +8,8 @@ Discovery.directive('slDiscoverySchema', [
   }
 ]);
 Discovery.directive('slDiscoveryModelPreview', [
-  function() {
+  'growl',
+  function(growl) {
     return {
       replace: true,
       templateUrl: './scripts/modules/discovery/templates/discovery.model.preview.html',
@@ -56,7 +57,7 @@ Discovery.directive('slDiscoveryModelPreview', [
               checkboxCellTemplate: '<label class="select-item-cell"><span class="sl-icon sl-icon-checkmark"></span><input type="checkbox" /></label>',
               showSelectionCheckbox: true,
               selectWithCheckboxOnly: false,
-              selectedItems:  scope.masterSelectedProperties[i],
+              selectedItems: scope.masterSelectedProperties[i],
               multiSelect: true,
               beforeSelectionChange: beforeSelectionChange,
               rowHeight: 40,
@@ -72,13 +73,25 @@ Discovery.directive('slDiscoveryModelPreview', [
     };
 
     function beforeSelectionChange(rowItem) {
-      if (!Array.isArray(rowItem))
-        return rowItem.entity._selectable;
+      var changeAllowed;
+      if (!Array.isArray(rowItem)) {
+        changeAllowed = !!rowItem.entity._selectable;
+        if (!changeAllowed)
+          warn('The row must be always selected.');
+      } else {
+        // rowItem.all(isSelectable)
+        changeAllowed = !rowItem.some(function(item) {
+          return !item._selectable;
+        });
+        if (!changeAllowed)
+          warn('Some of the rows must be always selected.');
+      }
 
-      // rowItem.all(beforeSelectionChange)
-      return !rowItem.some(function(item) {
-        return !beforeSelectionChange(item);
-      });
+      return changeAllowed;
+
+      function warn(msg) {
+        growl.addWarnMessage(msg, { ttl: 1000 });
+      }
     }
   }
 ]).filter('isIdFilter', function() {

--- a/client/www/scripts/modules/discovery/templates/discovery.modal.html
+++ b/client/www/scripts/modules/discovery/templates/discovery.modal.html
@@ -1,6 +1,7 @@
 <div ng-controller="DiscoveryMainController" class="discovery-modal-container">
   <div class="modal-header">
     <p>New Models from "{{targetDiscoveryDSName}}"</p>
+    <div growl></div>
   </div>
   <div class="modal-body">
     <div sl-discovery-schema></div>


### PR DESCRIPTION
See #808 

This patch adds `beforeSelectionChange` that prevents de-selection of properties that are `id` or `required`. It does not make sense to import a model without that properties, because such model definition would be invalid, an attempt to save it to the database will fail.

~~The downside of the solution proposed in this patch: there is no indication on why certain properties cannot be deselected, which may be confusing for the user. I am not sure how to solve that. We can use a different colour of the check-mark icon, add a tooltip, anything else?~~

/to @seanbrookes @anthonyettinger please review
/cc @altsang
