### PR TITLE
Default to one-shot mode for App Controller start

### DIFF
--- a/build-deploy/common/models/deployment.js
+++ b/build-deploy/common/models/deployment.js
@@ -11,7 +11,7 @@ module.exports = function(Deployment) {
     var cwd = process.cwd();
 
     if(deployment.type === 'local') {
-      deployment.processes = deployment.processes || 1;
+      deployment.processes = deployment.processes || -1;
       baseURL = 'http://localhost:'
               + process.server.address().port
               + '/process-manager';

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "split": "~0.3.1",
     "strong-build": "^1.0.2",
     "strong-deploy": "^1.1.0",
-    "strong-pm": "^1.5.0",
+    "strong-pm": "^1.6.0",
     "ws": "~0.4.32"
   },
   "description": "A visual suite for the StrongLoop API Platform",


### PR DESCRIPTION
Negative sizes indicate the number of workers to start, that will NOT be
restarted on failure. This changes the default from 1 worker, to 1
worker with no restart on failure.

See:

- https://github.com/strongloop/strong-supervisor/pull/83
- https://github.com/strongloop-internal/scrum-nodeops/issues/240
- https://github.com/strongloop/strong-pm/pull/95

I will try to add to this PR the changes mentioned in the top-level issue:
https://github.com/strongloop-internal/scrum-nodeops/issues/240#issuecomment-69138014

After this PR, with a loopback example app that has had it's node_modules directory removed (so fails pretty fast and hard), the result is the app does NOT get restarted, and remains in this state:

```
loopback-example-app
   (spinner)
RETRIEVING PORT
```

In this state, it can be stopped, and started again, at which point it will still spin. This addresses:

- strongloop/strong-arc#696
- strongloop/strong-arc#695