### PR TITLE
fix label for selected pid in profiler

### DIFF
--- a/devtools/frontend/profiler/ProfileLauncherView.js
+++ b/devtools/frontend/profiler/ProfileLauncherView.js
@@ -112,7 +112,7 @@ WebInspector.ProfileLauncherView.prototype = {
 
             var title = ( 'Create a profile for <span class="server">' +
                 server.host + ( showPort ? ':' + server.port : '') +
-                '</span> <span class="pid"></span>' );
+                '</span>, process ID#<span class="pid"></span>' );
 
             this._setTitle(title);
         }.bind(this));


### PR DESCRIPTION
- add comma and "process ID#" label

/cc @seanbrookes 