### PR TITLE
process-manager: disable pmctl channel

### DIFF
--- a/process-manager/process-manager.js
+++ b/process-manager/process-manager.js
@@ -17,7 +17,7 @@ function ProcessManager(root) {
 ProcessManager.prototype.start = function(cb) {
   var pm = this;
   var pathToPm = require.resolve('strong-pm/bin/sl-pm');
-  var args = [pathToPm, '--listen', '0'];
+  var args = [pathToPm, '--listen', '0', '--no-control'];
 
   this.setStatus('starting');
 


### PR DESCRIPTION
The local `pmctl` socket cannot be created on some filesystems (such as
vboxsf), and its only use for CLI access to the manager using `slc
pmctl`. This feature is not needed when arc is hosting the application,
so disable it.

Fix https://github.com/strongloop/strongloop/issues/179#issuecomment-71919097