### PR TITLE
tests: loosen timeouts to account for slow VMs

### DIFF
--- a/client/test/integration/spec/common/workspace-service.ispec.js
+++ b/client/test/integration/spec/common/workspace-service.ispec.js
@@ -1,4 +1,5 @@
 describe('WorkspaceService', function() {
+  this.timeout(10000);
   var CONST, WorkspaceService, throwHttpError, $injector;
   beforeEach(function() {
     inject(function(_$injector_) {


### PR DESCRIPTION
Testing the theory that the failures on CI are being caused by the VMs being slow.