### PR TITLE
fix metrics memory leak

### DIFF
--- a/client/www/scripts/modules/metrics/metrics.controllers.js
+++ b/client/www/scripts/modules/metrics/metrics.controllers.js
@@ -269,12 +269,15 @@ Metrics.controller('MetricsMainController', [
     }
 
     function renderTheCharts() {
+
+      // clear memory to avoid leaks
+      ChartConfigService.clearChartMemory();
+
       // assign scope chart model variable data here
       $scope.chartData.map(function(chart) {
         var data = $scope.currentStub[chart.name];
         $scope[chart.chartConfig] = ChartConfigService.getChartOptions(chart.chartOptions);
         $scope[chart.chartModel] = ChartConfigService.getChartMetricsData(chart, data);
-
       });
 
     }

--- a/client/www/scripts/modules/metrics/metrics.services.js
+++ b/client/www/scripts/modules/metrics/metrics.services.js
@@ -114,6 +114,13 @@ Metrics.service('ChartConfigService', [
       return isActive; //  temporary
 
     }
+    svc.clearChartMemory = function() {
+      // a bit of a hack to solve a memory leak in nvd3 when
+      // updated multiple charts at the same time
+      if (window.nv && window.nv.graphs) {
+        window.nv.graphs = [];
+      }
+    };
     svc.toggleMetricStatus = function(chartMetric) {
       // find metric in the current chart config data
       loop1:


### PR DESCRIPTION
- nvd3 has a global object 'nv'
 - it has a property 'graphs' which was not
 getting cleared each time we iterated and updated
 the charts
 - I set a manual reset of the data before we preocess
 our metrics 'tick' and it seems to have done the trick

Fixes strongloop/strong-arc#1050