### PR TITLE
fix app controller shows wrong status

### DIFF
--- a/client/www/scripts/modules/manager/templates/manager.main.html
+++ b/client/www/scripts/modules/manager/templates/manager.main.html
@@ -7,7 +7,10 @@
       </div>
     </div>
     <div class="app-context">
-      {{ appContext.name }} {{ appContext.version }}
+      {{ appContext.name }}
+      <span ng-if="appContext.version">
+        {{ appContext.version }}
+      </span>
     </div>
 
     <form class="ui-form has-table" name="form" novalidate ng-submit="save(form)">


### PR DESCRIPTION
The strong-pm not longer reports the application version in the instance model, which causing strong-mesh-client to incorrectly report no app was running.

A separate fix will be going into strong-mesh-client to fix the null-app issue, this fix corrects a minor visual quirk that occurs when the version is null.

connect to #1129