### PR TITLE
hide empty metrics charts

### DIFF
--- a/client/www/scripts/modules/metrics/metrics.controllers.js
+++ b/client/www/scripts/modules/metrics/metrics.controllers.js
@@ -349,6 +349,18 @@ Metrics.controller('MetricsMainController', [
       return $scope[modelRef];
     };
 
+    $scope.showChart = function(chart, modelRef) {
+      var data = $scope[modelRef];
+
+      if (data) {
+        return data.some(function(x) {
+          return x.values && x.values.length > 0;
+        });
+      }
+
+      return false;
+    };
+
     /*
     *
     *

--- a/client/www/scripts/modules/metrics/templates/metrics.chart.container.html
+++ b/client/www/scripts/modules/metrics/templates/metrics.chart.container.html
@@ -2,7 +2,7 @@
   <div ng-repeat="chart in chartData" class="chart-container">
     <div data-ui-type="table">
       <div data-ui-type="row">
-        <div data-ui-type="cell" class="main-chart-col">
+        <div data-ui-type="cell" class="main-chart-col" ng-show="showChart(chart, chart.chartModel)">
           <ul class="metrics-chart-controls">
             <li ng-repeat="metric in chart.metrics">
               <label class="" ng-click="toggleChartMetric(metric)">


### PR DESCRIPTION
Hide metrics charts where no data is currently available. This prevents some charts from showing ‘pending data’ indefinitely.

connect to #938