### PR TITLE
Change the app-controller port

### DIFF
--- a/process-manager/process-manager.js
+++ b/process-manager/process-manager.js
@@ -19,9 +19,7 @@ ProcessManager.prototype.start = function(cb) {
   var pm = this;
   var pathToPm = require.resolve('strong-pm/bin/sl-pm');
   var args = [pathToPm, '--listen', '0', '--no-control'];
-  var envOverrides = {
-    PORT: '3001'
-  };
+  var envOverrides = {};
 
   this.setStatus('starting');
 


### PR DESCRIPTION
Change the port used for applications run from the Arc app-controller
to 2999 to avoid conflicting with the port used by the multi-app PM.

connect to strongloop-internal/scrum-nodeops#518