### PR TITLE
Fix showing all pids on PM

### DIFF
--- a/client/www/scripts/modules/pm/pm.directives.js
+++ b/client/www/scripts/modules/pm/pm.directives.js
@@ -157,7 +157,10 @@ PM.directive('slPmHostForm', [
                     .then(function(pidCollection) {
 
                       PMHostService.addPMServer(serverConfig, false);
-                      $scope.processes = pidCollection;
+                      $scope.processes = pidCollection
+                        .filter(function(process) {
+                          return process.serviceInstanceId === 1;
+                        });
                       $scope.pmServers = PMHostService.getPMServers();
                       //activate first process
                       if ( $scope.processes.length ) {


### PR DESCRIPTION
Hide PIDs which do not belong to secondary applications (do not belong
to the first service instance).

connect to strongloop-internal/scrum-nodeops#514