### PR TITLE
Add support for feature flags

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -17,6 +17,10 @@ var opts = minimist(process.argv.slice(2), {
     'help',
     'cli',
   ],
+  string: [
+    'feature',
+    'features',
+  ],
 });
 
 var argv = getArgv();
@@ -30,6 +34,16 @@ if (opts.help) {
 }
 
 var arc = require('../server/server');
+
+// --features foo,bar --feature baz --feature quux
+//  => {feaures: 'foo,bar', feature: ['baz', 'quux']}
+//  => ['foo', 'bar', 'baz', 'quux']
+var features = [].concat(opts.feature, opts.features).map(function(f) {
+  return f && f.split(',');
+}).reduce(function(acc, f) {
+  return f ? acc.concat(f) : acc;
+}, []);
+arc.enableFeatures(features);
 
 if (pathArg) {
   WORKSPACE_DIR = path.join(WORKSPACE_DIR, pathArg);

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -2,24 +2,36 @@
 var path = require('path');
 var util = require('util');
 var opener = require('opener');
+var minimist = require('minimist');
 var DEFAULT_ARC_HOST = 'localhost';
 var STRONG_ARC_RUNNING_MSG =
 exports.STRONG_ARC_RUNNING_MSG = 'StrongLoop Arc is running here:';
+var opts = minimist(process.argv.slice(2), {
+  alias: {
+    v: 'version',
+    h: 'help',
+  },
+  boolean: [
+    'licenses',
+    'version',
+    'help',
+    'cli',
+  ],
+});
+
 var argv = getArgv();
-var pathArg = argv[0];
+var pathArg = opts._[0];
 var WORKSPACE_DIR = process.cwd();
 
-if (argv.indexOf('-h') !== -1 || argv.indexOf('--help') !== -1) {
-  printHelp();
-  return;
-} else if (argv.indexOf('-v') !== -1 || argv.indexOf('--version') !== -1) {
-  printVersion();
-  return;
+if (opts.help) {
+  return printHelp();
+} else if (opts.version) {
+  return printVersion();
 }
 
 var arc = require('../server/server');
 
-if(pathArg && pathArg.indexOf('--licenses') === -1 ) {
+if (pathArg) {
   WORKSPACE_DIR = path.join(WORKSPACE_DIR, pathArg);
 }
 
@@ -39,7 +51,7 @@ var server = arc.listen(port, function(err) {
   }
 
   //add optional path if flag is passed
-  var path = '#/' + ( argv.indexOf('--licenses') > -1 ? 'licenses' : '' );
+  var path = '#/' + ( opts.licenses ? 'licenses' : '' );
   var url = util.format('http://%s:%s/%s', DEFAULT_ARC_HOST,
     server.address().port, path);
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "loopback-boot": "^2.6.5",
     "loopback-datasource-juggler": "^2.20.0",
     "loopback-workspace": "^3.10.0",
+    "minimist": "^1.1.1",
     "opener": "^1.4.0",
     "request": "^2.53.0",
     "serve-favicon": "^2.2.0",

--- a/server/server.js
+++ b/server/server.js
@@ -25,6 +25,27 @@ app.use('/process-manager', pm);
 app.use('/api', arcApi);
 app.use('/manager', meshProxy);
 
+app.enableFeatures = function(features) {
+  // prefix is to namespace features in express config table
+  features = features.map(function(f) {
+    return 'feature:' + f;
+  });
+  features.forEach(function(f) {
+    app.enable(f);
+  });
+  // expose features list via REST so they can be checked by frontend
+  app.get('/feature-flags', function(req, res) {
+    res.json(features);
+  });
+
+  // example feature, "--feature crash" enables a /crash handler
+  if (app.enabled('feature:crash')) {
+    app.use('/crash', function(_req, _res) {
+      process.exit(1);
+    });
+  }
+};
+
 try {
   // API explorer
   var explorer = require('loopback-explorer');


### PR DESCRIPTION
Adds support for enabling features at start up using the `--feature/--features` CLI flag:
 * `slc arc --feature something-experimental` => `feature:something-experimental`
 * `slc arc --features foo,bar` => `feature:foo, feature:bar`
 * `slc arc --feature a --feature b --feature c` => `feature:a, feature:b, feature:c`
 * `slc arc --feature a,b --features c,d` => `feature:a, feature:b, feature:c, feature:d`

Features are exposed internally as booleans in the express config table and as a `/feature-flags` endpoint that returns a JSON array of the features enabled.

Includes an example `slc arc --feature crash` that adds a `/crash` API endpoint that kills Arc.

@altsang @chandadharap @anthonyettinger @seanbrookes @ritch @jtary PTAL and assign to someone appropriate to review