### PR TITLE
set feature flags earlier in boot

### DIFF
--- a/arc-api/server/models/arc-app.js
+++ b/arc-api/server/models/arc-app.js
@@ -1,5 +1,5 @@
 module.exports = function(ArcApp) {
-  var app = require('../server');
+  var appServer = require('../server');
 
   ArcApp.list = function(cb) {
     var all = ArcApp.getAll();
@@ -78,7 +78,13 @@ module.exports = function(ArcApp) {
       "disabled": true,
       "supports": "*"
     }
-  ].map(function(app) {
+  ].filter(function(app) {
+    if (app.featureFlag) {
+      return appServer.enabled(app.featureFlag);
+    } else {
+      return true;
+    }
+  }).map(function(app) {
     var arcApp = new ArcApp(app);
     return arcApp;
   });

--- a/arc-api/server/models/arc-app.js
+++ b/arc-api/server/models/arc-app.js
@@ -75,7 +75,7 @@ module.exports = function(ArcApp) {
       "id": "advisor",
       "name": "Node Advisor",
       "description": "Browse and search curated Node modules with developer reviews.",
-      "disabled": true,
+      "featureFlag": "feature:advisor",
       "supports": "*"
     }
   ].filter(function(app) {

--- a/arc-api/server/server.js
+++ b/arc-api/server/server.js
@@ -1,5 +1,10 @@
 var loopback = require('loopback');
 var boot = require('loopback-boot');
+var path = require('path');
 var app = module.exports = loopback();
+
+(process.env.SL_ARC_FEATURE_FLAGS || '').split(path.delimiter).forEach(function(f) {
+  app.enable('feature:' + f);
+});
 
 boot(app, __dirname);

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -33,8 +33,6 @@ if (opts.help) {
   return printVersion();
 }
 
-var arc = require('../server/server');
-
 // --features foo,bar --feature baz --feature quux
 //  => {feaures: 'foo,bar', feature: ['baz', 'quux']}
 //  => ['foo', 'bar', 'baz', 'quux']
@@ -43,7 +41,9 @@ var features = [].concat(opts.feature, opts.features).map(function(f) {
 }).reduce(function(acc, f) {
   return f ? acc.concat(f) : acc;
 }, []);
-arc.enableFeatures(features);
+process.env.SL_ARC_FEATURE_FLAGS = features.join(path.delimiter);
+
+var arc = require('../server/server');
 
 if (pathArg) {
   WORKSPACE_DIR = path.join(WORKSPACE_DIR, pathArg);


### PR DESCRIPTION
After a bit of poking around it became clear that my original approach would not work with the way Arc loads its modules.

This sets the flags at the earliest possible moment and adds more direct support for toggling the apps listed in arc-api/server/models/arc-app.js

/cc @seanbrookes @chandadharap @altsang @anthonyettinger 