### PR TITLE
process-manager: pass --base explicitly

### DIFF
--- a/process-manager/process-manager.js
+++ b/process-manager/process-manager.js
@@ -18,8 +18,12 @@ function ProcessManager(root) {
 
 ProcessManager.prototype.start = function(cb) {
   var pm = this;
-  var pathToPm = require.resolve('strong-pm/bin/sl-pm');
-  var args = [pathToPm, '--listen', '0', '--no-control'];
+  var args = [
+    require.resolve('strong-pm/bin/sl-pm'),
+    '--listen=0',
+    '--base=.strong-pm',
+    '--no-control',
+  ];
   var envOverrides = {};
 
   this.setStatus('starting');


### PR DESCRIPTION
arc uses pm 3.x, but 4.x has changed the default behaviour of --base to
be ~/.strong-pm. arc must continue to use a .strong-pm in the same
directory that arc is started.

Not strictly necessary, but maybe a good idea?

connected to strongloop-internal/scrum-nodeops#640