### PR TITLE
use global jQuery and d3 in tracing modules

### DIFF
--- a/client/www/scripts/lib/d3-from-global.js
+++ b/client/www/scripts/lib/d3-from-global.js
@@ -1,0 +1,4 @@
+// exports the already global d3 in a way that require() likes
+// this is used by browserify in the strong-arc build process to replace
+// references to require('d3') with require('./path/to/this/file')
+module.exports = (window || global).d3;

--- a/client/www/scripts/lib/jquery-from-global.js
+++ b/client/www/scripts/lib/jquery-from-global.js
@@ -1,0 +1,4 @@
+// exports the already global jQuery in a way that require() likes
+// this is used by browserify in the strong-arc build process to replace
+// references to require('jquery') with require('./path/to/this/file')
+module.exports = (window || global).jQuery;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -132,6 +132,8 @@ gulp.task('build-help-assets', function(callback) {
 gulp.task('build-tracing-bundle', function() {
   var bSource = './client/www/scripts/modules/tracing/src/tracing.viz.module.js';
   return browserify(bSource, {standalone: 'TracingViz'})
+    .require('./client/www/scripts/lib/jquery-from-global.js', {expose: 'jquery'})
+    .require('./client/www/scripts/lib/d3-from-global.js', {expose: 'd3'})
     .bundle()
     .pipe(fs.createWriteStream('./client/www/scripts/modules/tracing/tracing.viz.module.js'));
 });


### PR DESCRIPTION
Tell browserify to use stub modules whenever it sees require('jquery')
or require('d3'). The stubs it uses are simple wrappers that export
window.jQuery and window.d3, respectively.

This allows them to use the globally loaded versions of those libraries
instead of bundling and using their own versions.

/cc @sam-github @Setogit 