### PR TITLE
build-deploy: use exit status for success/fail

### DIFF
--- a/client/www/scripts/modules/build-deploy/build-deploy.services.js
+++ b/client/www/scripts/modules/build-deploy/build-deploy.services.js
@@ -17,21 +17,14 @@ BuildDeploy.service('BuildDeployService', [
         .then(function(updatedBuild) {
           buildData.build = updatedBuild;
 
-          //viewConsole.logs = updatedBuild.stdout;
           viewConsole.logs = viewConsole.logs.concat(updatedBuild.stdout, updatedBuild.stderr);
           viewConsole.logs = _.uniq(viewConsole.logs);
 
-          //remove array items with empty values
-          updatedBuild.stderr = updatedBuild.stderr.filter(function(item){
-            return item.length;
-          });
-
-          if ( updatedBuild.stderr.length ) {
-            def.reject(updatedBuild);
-          }
-
           if (updatedBuild.finished) {
-            def.resolve(updatedBuild);
+            if (updatedBuild.errorCode)
+              def.reject(updatedBuild);
+            else
+              def.resolve(updatedBuild);
           } else {
             $timeout(function(){
               poll(def, buildData, build, viewConsole);
@@ -40,14 +33,14 @@ BuildDeploy.service('BuildDeployService', [
         });
     }
 
-    //1. start build
+    // 1. start build
     function startBuild(buildData, viewConsole){
       var def = $q.defer();
 
       // 1. Build.start();
       Build.start(buildData).$promise
         .then(function(build) {
-          // reference the build from teh view if needed
+          // reference the build from the view if needed
           buildData.build = build;
           viewConsole.logs.push('STARTING BUILD....');
           viewConsole.logs = viewConsole.logs.concat(build.stdout, build.stderr);

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "serve-favicon": "^2.2.0",
     "sha1": "^1.1.0",
     "split": "^0.3.3",
-    "strong-build": "^1.0.3",
+    "strong-build": "^2.x",
     "strong-deploy": "^1.1.4",
     "strong-mesh-client": "^1.4.0",
     "strong-pm": "^3.0.0",


### PR DESCRIPTION
connected to strongloop-internal/scrum-nodeops#600

Code used to be assuming that any stderr lines indicated build failure,
and reporting an error to the user. Despite the error, the build would
continue in the background and often succeed.

Correct strategy is to use sl-build exit status. The build "flakiness"
is easily reproduceable by running `DEBUG=strong-build* slc arc`,
because debug output goes to stderr, it would cause all builds to be
considered to have failed.

Other fixes:

- handle spawn error events
- use debug library so that component is debuggable
- some deletion of dead code and fixing of comment typos
- sorting of require statements