### PR TITLE
Fix controls being locked after profiling

### DIFF
--- a/client/www/scripts/modules/profiler/profiler.directives.js
+++ b/client/www/scripts/modules/profiler/profiler.directives.js
@@ -162,6 +162,7 @@ Profiler.directive('slProfilerNavbar', [
             $scope.fetchHeapFile()
               .then(function(profile) {
                 $scope.profiles.push(profile);
+                cb(null);
               });
           };
           // fix profiler header disappearing when files are loaded in the iframe, etc

--- a/devtools/frontend/profiler/ProfileLauncherView.js
+++ b/devtools/frontend/profiler/ProfileLauncherView.js
@@ -118,6 +118,10 @@ WebInspector.ProfileLauncherView.prototype = {
                   this._toggleCpuButtons('start');
                   this._enableProfilerRadioButtons();
               }
+            } else {
+              if (!profilerRunning) {
+                this._enableProfilerRadioButtons();
+              }
             }
 
             this._setTitlePid(text);


### PR DESCRIPTION
Fix being unable to change profiling type after running a heap
snapshot, and profile status being overridden by updates.

connect to strongloop-internal/scrum-loopback#326