### PR TITLE
devtools: fix issues in the debugger UI

### DIFF
--- a/devtools/frontend/sdk/ResourceTreeModel.js
+++ b/devtools/frontend/sdk/ResourceTreeModel.js
@@ -437,7 +437,7 @@ WebInspector.ResourceTreeModel.prototype = {
         var frame = new WebInspector.ResourceTreeFrame(this, parentFrame, framePayload.id, framePayload);
         this._addFrame(frame);
 
-        var frameResource = this._createResourceFromFramePayload(framePayload, framePayload.url, WebInspector.resourceTypes.Document, framePayload.mimeType);
+        var frameResource = this._createResourceFromFramePayload(framePayload, framePayload.url, WebInspector.resourceTypes.Script, framePayload.mimeType);
         if (frame.isMainFrame())
             this._inspectedPageURL = frameResource.url;
         frame.addResource(frameResource);

--- a/devtools/frontend/ui/treeoutline.js
+++ b/devtools/frontend/ui/treeoutline.js
@@ -1008,8 +1008,8 @@ TreeElement.prototype.traversePreviousTreeElement = function(skipUnrevealed, don
 TreeElement.prototype.isEventWithinDisclosureTriangle = function(event)
 {
     // FIXME: We should not use getComputedStyle(). For that we need to get rid of using ::before for disclosure triangle. (http://webk.it/74446)
-    var paddingLeftValue = window.getComputedStyle(this._listItemNode).getPropertyCSSValue("padding-left");
-    var computedLeftPadding = paddingLeftValue ? paddingLeftValue.getFloatValue(CSSPrimitiveValue.CSS_PX) : 0;
+    var paddingLeftValue = window.getComputedStyle(this._listItemNode).getPropertyValue("padding-left");
+    var computedLeftPadding = paddingLeftValue ? paddingLeftValue : 0;
     var left = this._listItemNode.totalOffsetLeft() + computedLeftPadding;
     return event.pageX >= left && event.pageX <= left + this.arrowToggleWidth && this.hasChildren;
 }


### PR DESCRIPTION
 - mark the top-level resource as Script
 - replace no-longer-supported `getPropertyCSSValue()`

/cc @anthonyettinger FYI, these changes are based on fixes in Node Inspector, I don't think there is much to review here.