### PR TITLE
build-tasks: fix options to writeJsonFile

### DIFF
--- a/build-tasks/download-help-assets.js
+++ b/build-tasks/download-help-assets.js
@@ -50,7 +50,7 @@ function downloadHelpHtml(id, name, destDir, cb) {
     var fileName = path.join(destDir, name + '.json');
 
     gutil.log('Creating help file ' + fileName);
-    fs.writeJsonFile(fileName, data, 'utf-8', cb);
+    fs.writeJsonFile(fileName, data, {}, cb);
   });
 }
 


### PR DESCRIPTION
Work around https://github.com/jprichardson/node-jsonfile/issues/28

npm install of strong-arc fails without this.

`'utf-8'` is the default encoding, so it shouldn't be necessary to specify it.