### PR TITLE
Fix heap snapshot flicker

### DIFF
--- a/client/www/scripts/modules/profiler/profiler.directives.js
+++ b/client/www/scripts/modules/profiler/profiler.directives.js
@@ -73,7 +73,7 @@ Profiler.directive('slProfilerNavbar', [
                   id: data.data.result.profileId,
                   targetId: pid,
                   startTime: new Date(),
-                  status: 'ready',
+                  status: 'profiling',
                   type: 'heapsnapshot',
                   downloadUrl: fileUrl
                 };


### PR DESCRIPTION
Fix issue with heap snapshots disappearing immediately after being run, only to reappear after a short delay.

connect to strongloop-internal/scrum-loopback#355