### PR TITLE
Remove PID selector from API Analytics

### DIFF
--- a/client/www/scripts/modules/api-analytics/api.analytics.controllers.js
+++ b/client/www/scripts/modules/api-analytics/api.analytics.controllers.js
@@ -26,18 +26,6 @@ ApiAnalytics.controller('ApiAnalyticsController', [
         $scope.getData(null, 0, 0);
       };
 
-      $scope.updateProcesses = function(processes) {
-        $scope.processes = processes;
-        $scope.updateProcessSelection([processes[0]]);
-      };
-
-      $scope.updateProcessSelection = function(selection) {
-        if (selection.length) {
-          selection[0].isActive = true;
-          $scope.activeProcess = selection[0];
-        }
-      };
-
       $scope.getData = function(d, i, depth, initialModel){
         var def = $q.defer();
 

--- a/client/www/scripts/modules/api-analytics/templates/api.analytics.main.html
+++ b/client/www/scripts/modules/api-analytics/templates/api.analytics.main.html
@@ -8,8 +8,7 @@
             <section>
               <sl-pm-pid-selector
                 on-update-host="updateHost(host)"
-                on-update-processes="updateProcesses(processes)"
-                on-update-selection="updateProcessSelection(selection)">
+                show-pid-selector="false">
               </sl-pm-pid-selector>
               <sl-api-analytics-chart
                 chart="apiChart"

--- a/client/www/scripts/modules/pm/pm.directives.js
+++ b/client/www/scripts/modules/pm/pm.directives.js
@@ -528,10 +528,18 @@ PM.directive('slPmPidSelector', [
         onUpdateHost: '&',
         onUpdateProcesses: '&',
         onUpdateSelection: '&',
+        showPidSelector: '=',
         multiple: '='
       },
       controller: function($scope) {
         $scope.processes = [];
+        $scope._showPidSelector = true;
+
+        $scope.$watch('showPidSelector', function(newVal) {
+          if (angular.isDefined(newVal)) {
+            $scope._showPidSelector = !!newVal;
+          }
+        });
 
         $scope.updateProcesses = function(processes, refresh) {
           $scope.processes = processes;

--- a/client/www/scripts/modules/pm/templates/pm.pid.selector.html
+++ b/client/www/scripts/modules/pm/templates/pm.pid.selector.html
@@ -7,7 +7,7 @@
   </div>
   <div class="extensions-container" ng-transclude ng-show="processes.length > 0">
   </div>
-  <div class="selector-containers">
+  <div class="selector-containers" ng-show="_showPidSelector">
     <div sl-pm-processes processes="processes" multiple="multiple"
       show-supervisor="false" on-update-selection="updateSelection(selection)"></div>
   </div>


### PR DESCRIPTION
Remove the PID selector from the API Analytics host selection form.