### PR TITLE
Hide app-controller when not supported

### DIFF
--- a/client/www/index.html
+++ b/client/www/index.html
@@ -23,7 +23,7 @@
   <sl-app-selector></sl-app-selector>
   <div class="navButtons">
     <ul>
-      <li ng-show="isAuthUser()">
+      <li ng-show="isAuthUser() && supportAppController">
         <div sl-pm-app-controller-menu class="header-pm-app-control-menu-item"></div>
       </li>
       <li class="header-help-container" ng-show="helpId">

--- a/client/www/scripts/modules/arc/arc.controllers.js
+++ b/client/www/scripts/modules/arc/arc.controllers.js
@@ -4,7 +4,8 @@ Arc.controller('ArcMainController', [
   'ArcUserService',
   '$log',
   '$rootScope',
-  function($scope, ArcUserService, $log, $rootScope){
+  'LandingService',
+  function($scope, ArcUserService, $log, $rootScope, LandingService){
 
     $scope.suiteIA = {
       apps: []
@@ -23,6 +24,19 @@ Arc.controller('ArcMainController', [
     $scope.pageClick = function($event){
       $rootScope.$broadcast('pageClick', $event);
     };
+
+    $scope.supportAppController = false;
+
+    LandingService.getApps().$promise
+      .then(function(response) {
+        var buildApp = response.results.filter(function(d) {
+          return d.id === 'build-deploy';
+        });
+
+        if (buildApp.length) {
+          $scope.supportAppController = buildApp[0].supportsCurrentProject;
+        }
+      });
 }]);
 
 
@@ -50,6 +64,3 @@ Arc.controller('GlobalNavController',[
     };
   }
 ]);
-
-
-

--- a/client/www/scripts/modules/landing/landing.controllers.js
+++ b/client/www/scripts/modules/landing/landing.controllers.js
@@ -17,4 +17,3 @@ Landing.controller('LandingController', [
     });
   }
 ]);
-


### PR DESCRIPTION
Hide the app controller from the nav menu when running Arc outside of a
project directory.

connect to #925