### PR TITLE
Exclude Workspace model from test server reset

### DIFF
--- a/client/test/test-server.js
+++ b/client/test/test-server.js
@@ -35,7 +35,12 @@ arc.post('/reset', function(req, res, next) {
   }
 
   var modelsToReset = workspace.models().filter(function(m) {
-    return m !== 'PackageDefinition' && m !== 'Facet' && m !== 'ConfigFile';
+    return [
+      'PackageDefinition',
+      'Facet',
+      'ConfigFile',
+      'Workspace'
+    ].indexOf(m.modelName) === -1;
   });
 
   async.eachSeries(


### PR DESCRIPTION
The original implementation of the `modelsToReset` filter was comparing a `ModelCtor` with a `String`. I've fixed this and added `Workspace` to the list.

/to @rmg 
/cc @bajtos 