### PR TITLE
fix failing Windows builds on CI

### DIFF
--- a/client/test/.jshintrc
+++ b/client/test/.jshintrc
@@ -27,6 +27,7 @@
   "browser": true,
   "inject": true,
   "given": true,
-  "protractor": true
+  "protractor": true,
+  "window": true
 }
 }

--- a/client/test/integration/karma.integration.js
+++ b/client/test/integration/karma.integration.js
@@ -1,6 +1,10 @@
 // Karma configuration
 
 module.exports = function(config) {
+
+  // tell the integration tests that there is no MySQL server setup
+  config.client.SKIP_MYSQL = process.env.SKIP_MYSQL;
+
   config.set({
 
     // base path, that will be used to resolve files and exclude
@@ -158,6 +162,9 @@ module.exports = function(config) {
 
     // If browser does not capture in given timeout [ms], kill it
     captureTimeout: 5000,
+
+    // If browser is idle
+    browserNoActivityTimeout: 20000,
 
     //preprocessors: {
     //  './e2e/**/*.spec.js': [ 'browserify' ]

--- a/client/test/integration/spec/smoke.ispec.js
+++ b/client/test/integration/spec/smoke.ispec.js
@@ -12,7 +12,9 @@ describe('Arc', function() {
     });
   });
 
-  it('can autoupdate MySQL database', function() {
+  (window.__karma__.config.SKIP_MYSQL ?
+   it.skip : it)('can autoupdate MySQL database', function() {
+
     // We need more time for tests to finish on Jenkins
     this.timeout(5000);
 

--- a/client/test/test-server.js
+++ b/client/test/test-server.js
@@ -103,7 +103,7 @@ var server = arc.listen(port, function(err) {
     process.send(server.address());
   }
   if (process.argv.length > 2)
-    runAndExit(process.argv[2], process.argv.slice(3));
+    runAndExit(process.execPath, process.argv.slice(2));
 });
 
 function runAndExit(cmd, args) {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -327,6 +327,7 @@ gulp.task('setup-mysql', function(callback) {
   });
 
   function logMysqlErrorDescription(err) {
+    process.env.SKIP_MYSQL = process.env.SKIP_MYSQL || err.code;
     switch (err.code) {
       case 'ECONNREFUSED':
         logRed('Cannot connect to the MySQL server.');

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -294,7 +294,7 @@ gulp.task('test-client-integration', function(callback) {
     process.execPath,
     [
       'client/test/test-server',
-      'node_modules/.bin/karma',
+      require.resolve('karma/bin/karma'),
       'start',
       '--single-run',
       '--browsers',


### PR DESCRIPTION
There were 3 general problems, and they're the same problems that usually come up when dealing with Windows:
 - using a UNIX style path for executables when calling `spawn()`
 - using synchronous "convenience" functions (they block the event loop, preventing the process from letting go of resources, which causes errors on Windows when you try to delete them)
 - tests not accounting for database servers not being accessible (specific to our Windows VMs at the moment)