### PR TITLE
Fix/410 final pm selector consolidation

### DIFF
--- a/client/less/tracing.less
+++ b/client/less/tracing.less
@@ -7,19 +7,14 @@
   }
   hr {
     margin-top:.4rem;
-
-
   }
-  .sl-pid-selector {
 
-    .sl-profiler-processes {
-      min-height:0;
-    }
-  }
   .tracing-header-container {
     margin-top: .7rem;
 
     .tracing-header-controls-container {
+      display:flex;
+      flex-direction: row;
       font-size:1.4rem;
       color:#999999;
     }
@@ -28,29 +23,6 @@
       height:125px;
     }
 
-
-      .pm-host-selector-container {
-        position:relative;
-        display:inline-block;
-        margin:0 1rem 0 1rem;
-
-        .dropdown-menu {
-          top:6rem;
-          left:0;
-        }
-      }
-
-    .sl-pid-selector {
-      position:relative;
-      vertical-align: middle;
-      display:inline-block;
-      margin-left:1rem;
-      margin-right:1rem;
-
-      .sl-profiler-processes {
-        min-height:0;
-      }
-    }
       .pm-status-container {}
       .pm-tracing-toggle-container {
         display:inline-block;
@@ -128,34 +100,11 @@
       display: block;
       margin-bottom: 0.75rem;
     }
-    .tracing-header-controls-table {
-      width:100%;
-
-      td {
-
-        table.tracing-controls-table {
-
-          vertical-align: middle;
-
-          td.host-col {
-              min-width: 3rem;
-          }
-          td.pids-col {
-            min-width: 10rem;
-          }
-
-        }
-      }
-    }
   }
   .pm-host-select {
     .title {
       margin-bottom: 0.75rem;
     }
-  }
-
-  .sl-pid-selector {
-    display: inline-block;
   }
 
   h2 {

--- a/client/test/.jshintrc
+++ b/client/test/.jshintrc
@@ -27,6 +27,7 @@
   "browser": true,
   "inject": true,
   "given": true,
-  "protractor": true
+  "protractor": true,
+  "window": true
 }
 }

--- a/client/test/integration/karma.integration.js
+++ b/client/test/integration/karma.integration.js
@@ -1,6 +1,10 @@
 // Karma configuration
 
 module.exports = function(config) {
+
+  // tell the integration tests that there is no MySQL server setup
+  config.client.SKIP_MYSQL = process.env.SKIP_MYSQL;
+
   config.set({
 
     // base path, that will be used to resolve files and exclude
@@ -158,6 +162,9 @@ module.exports = function(config) {
 
     // If browser does not capture in given timeout [ms], kill it
     captureTimeout: 5000,
+
+    // If browser is idle
+    browserNoActivityTimeout: 20000,
 
     //preprocessors: {
     //  './e2e/**/*.spec.js': [ 'browserify' ]

--- a/client/test/integration/spec/smoke.ispec.js
+++ b/client/test/integration/spec/smoke.ispec.js
@@ -12,7 +12,9 @@ describe('Arc', function() {
     });
   });
 
-  it('can autoupdate MySQL database', function() {
+  (window.__karma__.config.SKIP_MYSQL ?
+   it.skip : it)('can autoupdate MySQL database', function() {
+
     // We need more time for tests to finish on Jenkins
     this.timeout(5000);
 

--- a/client/test/test-server.js
+++ b/client/test/test-server.js
@@ -22,17 +22,25 @@ var sandboxNeedsFullReset = false;
 var arc = require('../../server/server');
 var workspace = arc.workspace;
 
-// Inject `POST /reset` to reset the sandbox to initial state
-arc.post('/reset', function(req, res, next) {
-  console.log('--reset-start--');
-
-  if (sandboxNeedsFullReset) {
-    if (fs.existsSync(SANDBOX)) {
-      fs.removeSync(SANDBOX);
-    }
-    fs.copySync(EMPTY_PROJECT, SANDBOX);
-    sandboxNeedsFullReset = false;
+function resetSandbox(req, res, next) {
+  console.log('--reset-sandbox--');
+  if (!sandboxNeedsFullReset) {
+    return next();
   }
+  fs.remove(SANDBOX, function(err) {
+    if (err) {
+      return next(err);
+    }
+    fs.copy(EMPTY_PROJECT, SANDBOX, function(err) {
+      sandboxNeedsFullReset = false;
+      return next(err);
+    });
+  });
+}
+
+// Inject `POST /reset` to reset the sandbox to initial state
+arc.post('/reset', resetSandbox, function(req, res, next) {
+  console.log('--reset-start--');
 
   var modelsToReset = workspace.models().filter(function(m) {
     return [
@@ -103,7 +111,7 @@ var server = arc.listen(port, function(err) {
     process.send(server.address());
   }
   if (process.argv.length > 2)
-    runAndExit(process.argv[2], process.argv.slice(3));
+    runAndExit(process.execPath, process.argv.slice(2));
 });
 
 function runAndExit(cmd, args) {

--- a/client/www/scripts/modules/manager/manager.controllers.js
+++ b/client/www/scripts/modules/manager/manager.controllers.js
@@ -95,16 +95,6 @@ Manager.controller('ManagerMainController', [
 
     };
 
-
-
-
-
-
-
-
-
-
-
     $scope.isShowHostActionList = function(host) {
       if (host.isShowActionList === undefined) {
         return host.isShowActionList = false;
@@ -203,7 +193,9 @@ Manager.controller('ManagerMainController', [
 
       client.serviceList(function(err, service) {
         if (!err && service.length > 0) {
-          deferred.resolve(service[0]);
+          deferred.resolve(service[0].instances(function(err, instances) {
+            var first = instances[0].setSize
+          }));
         } else {
           deferred.reject(err);
         }
@@ -234,9 +226,6 @@ Manager.controller('ManagerMainController', [
           if (hosts && hosts.map) {
             var addressCollection = [];
 
-            //$scope.hostServers = ManagerServices.getHostServers();
-
-
             /*
             *
             * Iterate over the hosts to massage the data mode
@@ -265,8 +254,7 @@ Manager.controller('ManagerMainController', [
               * - edit
               * - delete
               * */
-              host.filteredActions = availableActions
-                .map(function(action) {
+              host.filteredActions = availableActions.map(function(action) {
                   return angular.extend({}, hostActionDefaults, action);
                 });
 
@@ -469,10 +457,6 @@ Manager.controller('ManagerMainController', [
         delete host.status;
 
         growl.addSuccessMessage("activate host ");
-        $log.debug('|');
-        $log.debug('| MESH CALL [SAVE HOST]');
-        $log.debug('|');
-
 
         host.save(function(err, response) {
           if (err) {

--- a/client/www/scripts/modules/manager/manager.services.js
+++ b/client/www/scripts/modules/manager/manager.services.js
@@ -111,7 +111,7 @@ Manager.service('ManagerServices', [
             break;
           }
           case 'unknown': {
-            if (host.error.message.indexOf('ETIMEDOUT') !== -1){
+            if (host.error.message && host.error.message.indexOf('ETIMEDOUT') !== -1){
               host.status.isProblem = true;
               host.status.isNoApp = false;
               host.status.isActive = false;
@@ -121,7 +121,7 @@ Manager.service('ManagerServices', [
             }
             else {
               host.status.problem.title = 'exception: ' + host.errorType;
-              host.status.problem.description = host.error.message;
+              host.status.problem.description = host.error.message || 'Unknown error';
             }
 
             break;

--- a/client/www/scripts/modules/manager/templates/manager.main.html
+++ b/client/www/scripts/modules/manager/templates/manager.main.html
@@ -1,5 +1,5 @@
 <div class="manager-main-layout">
-  <div class="manager-main-container" ng-controller="ManagerMainController">
+  <div class="manager-main-container">
     <div class="load-balancer-container">
       <button class="link-cmd ui-btn accessory" ng-click="toggleManagerLoadBalancer()" class="btn-toggle-loadbalancer">Load Balancer</button>
       <div class="load-balancer-content" ng-show="showManagerLoadBalancer">

--- a/client/www/scripts/modules/pm/pm.services.js
+++ b/client/www/scripts/modules/pm/pm.services.js
@@ -322,7 +322,6 @@ PM.service('PMHostService', [
     svc.getLatestPMServer = function(cb) {
       // get the last entry in the array
       //var pmServers = JSON.parse(window.localStorage.getItem('pmServers'));
-      $log.debug('get manager hosts 4');
       if (!cb) {
         $log.warn('CB is not a function');
         return;

--- a/client/www/scripts/modules/pm/templates/pm.pid.selector.html
+++ b/client/www/scripts/modules/pm/templates/pm.pid.selector.html
@@ -9,6 +9,7 @@
   </div>
   <div class="selector-container" ng-show="_showPidSelector">
     <div sl-pm-processes processes="processes" multiple="multiple"
-      show-supervisor="false" on-update-selection="updateSelection(selection)"></div>
+      show-supervisor="false" on-update-selection="updateSelection(selection)">
+    </div>
   </div>
 </div>

--- a/client/www/scripts/modules/tracing/templates/tracing.header.html
+++ b/client/www/scripts/modules/tracing/templates/tracing.header.html
@@ -1,65 +1,32 @@
 <div class="tracing-header-container">
   <div class="tracing-header-controls-container">
-    <table class="tracing-header-controls-table">
-      <tr>
-        <td>
-          <table class="tracing-controls-table">
-            <tr>
-              <td class="host-col">
-                <!-- host selector -->
-                <div ng-show="managerHosts.length > 0" class="pm-host-selector-container">
-                  <div class="btn-group pm-host-select dropdown" dropdown ng-show="managerHosts"  is-open="status.isopen">
-                    <span class="title">Host</span>
-                    <button type="button"
-                            class="btn btn-default dropdown-toggle" dropdown-toggle>
-                      {{selectedPMHost.host}} : {{selectedPMHost.port}}<span class="caret"></span>
-                    </button>
-                    <ul class="dropdown-menu" role="menu" dropdown-menu>
-                      <li ng-repeat="host in managerHosts">
-                        <button class="link-cmd" ng-click="changePMHost(host)">{{host.host}}:{{host.port}}</button>
-                      </li>
-                      <li class="divider"></li>
-                      <li>
-                        <button class="link-cmd" ng-click="goToAddPM()">add PM Host</button>
-                      </li>
-                    </ul>
-                  </div>
-                </div>
-              </td>
-              <td class="pids-col">
-                <!-- Processes list -->
-                <div class="sl-pid-selector" ng-show="processes.length > 0">
-                  <sl-tracing-processes></sl-tracing-processes>
-                </div>
-                <span class="loading" sl-common-loading-indicator size="small" ng-show="tracingProcessCycleActive"></span>
-              </td>
-              <td class="controls-col">
-                <!-- toggle control -->
-                <sl-tracing-host-status ng-show="!showTraceToggle"></sl-tracing-host-status>
-                <div class="pm-tracing-toggle-container" ng-show="showTraceToggle">
-                  <span class="title">Tracing</span>
-                  <sl-ui-switch switches="tracingOnOff"  ng-show="!tracingProcessCycleActive" classes="power"></sl-ui-switch>
-                  <div ng-show="tracingProcessCycleActive">{{tracingOnOffCycleMessage}} {{ ( processes.length + 1) }} of {{ targetProcessCount }} processes tracing</div>
-                </div>
-              </td>
-            </tr>
-          </table>
-        </td>
-        <td class="tracing-ticker-container">
-          <!-- ticker -->
-          <!-- Tracing ticker -->
-          <div class="tracing-ticker-container">
-            <div ng-hide="!tracingCtx.currentProcess.pid || tracingCtx.currentPFKey">
-              <span class="title" >Data Points: {{tracingCtx.currentTimelineKeyCollection.length}}</span>
-              <div sl-metrics-visual-ticker class="metrics-visual-ticker-container"></div>
-            </div>
-            <sl-tracing-prev-next ng-hide="tracingCtx.currentWaterfallKey"></sl-tracing-prev-next>
-          </div>
-        </td>
 
-      </tr>
+    <sl-pm-pid-selector
+      selected-host="selectedPMHost"
+      on-update-host="updateHost(host)"
+      on-update-processes="updateProcesses(processes)"
+      external-processes="processes"
+      on-update-selection="updateProcessSelection(selection)">
+    </sl-pm-pid-selector>
 
-    </table>
+    <span class="loading" sl-common-loading-indicator size="small" ng-show="tracingProcessCycleActive"></span>
+    <!-- toggle control -->
+    <sl-tracing-host-status ng-show="!showTraceToggle"></sl-tracing-host-status>
+    <div class="pm-tracing-toggle-container" ng-show="showTraceToggle">
+      <span class="title">Tracing</span>
+      <sl-ui-switch switches="tracingOnOff"  ng-show="!tracingProcessCycleActive" classes="power"></sl-ui-switch>
+      <div ng-show="tracingProcessCycleActive">{{tracingOnOffCycleMessage}} {{ ( processes.length + 1) }} of {{ targetProcessCount }} processes tracing</div>
+    </div>
+
+    <!-- ticker -->
+    <!-- Tracing ticker -->
+    <div class="tracing-ticker-container">
+      <div ng-hide="!tracingCtx.currentProcess.pid || tracingCtx.currentPFKey">
+        <span class="title" >Data Points: {{tracingCtx.currentTimelineKeyCollection.length}}</span>
+        <div sl-metrics-visual-ticker class="metrics-visual-ticker-container"></div>
+      </div>
+      <sl-tracing-prev-next ng-hide="tracingCtx.currentWaterfallKey"></sl-tracing-prev-next>
+    </div>
 
   </div>
   <hr />

--- a/client/www/scripts/modules/tracing/tracing.directives.js
+++ b/client/www/scripts/modules/tracing/tracing.directives.js
@@ -135,13 +135,6 @@ Tracing.directive('slTracingHeader', [
     return {
       templateUrl: './scripts/modules/tracing/templates/tracing.header.html',
       restrict: 'E',
-      controller: [
-        '$scope',
-        '$log',
-        function($scope, $log) {
-
-        }
-      ],
       link: function(scope, el, attrs) {
         scope.$watch('tracingCtx.currentPMInstance', function(newVal, oldVal) {
           // pm instance is up but app is stopped

--- a/client/www/scripts/modules/tracing/tracing.services.js
+++ b/client/www/scripts/modules/tracing/tracing.services.js
@@ -26,6 +26,22 @@ Tracing.service('TracingServices', [
           ]
         });
     };
+    svc.alertProcessLoadProblem = function(){
+
+      $rootScope.$emit('message', {
+          body: 'Not all processes are coming up.  Please check the pm host status.',
+          links: [{
+            link: '/#process-manager',
+            linkText: 'go to Process Manager view'
+          },
+          {
+            link: 'http://docs.strongloop.com/display/SLC/Tracing',
+            linkText: 'more info...'
+          }
+        ]
+      });
+    };
+
     svc.alertUnlicensedPMHost = function() {
       $rootScope.$emit('message', {
         body: 'The processes came up but they are not tracing.  You may need to push a license to your PM Host via the Process Manager view. Or you could try stopping and starting tracing again to reset.',

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -294,7 +294,7 @@ gulp.task('test-client-integration', function(callback) {
     process.execPath,
     [
       'client/test/test-server',
-      'node_modules/.bin/karma',
+      require.resolve('karma/bin/karma'),
       'start',
       '--single-run',
       '--browsers',
@@ -327,6 +327,7 @@ gulp.task('setup-mysql', function(callback) {
   });
 
   function logMysqlErrorDescription(err) {
+    process.env.SKIP_MYSQL = process.env.SKIP_MYSQL || err.code;
     switch (err.code) {
       case 'ECONNREFUSED':
         logRed('Cannot connect to the MySQL server.');


### PR DESCRIPTION
replace tracing pm host selector with the common one used elsewhere

- added the ability to inject the process collection into the comopnent so the hosting module (tracing) can process the processes based on whether they are tracing or not and override the collection in the process display.

connected to: strongloop-internal/scrum-loopback#410