### PR TITLE
convert links in profiler to spans

### DIFF
--- a/devtools/custom/less/overrides.less
+++ b/devtools/custom/less/overrides.less
@@ -142,3 +142,9 @@ body.inactive button.text-button, button.text-button {
 .sidebar-tree-item {
     color: @sidebar-color;
 }
+
+.profile-node-file.webkit-html-resource-link {
+    color: rgb(33%, 33%, 33%);
+    text-decoration: none;
+    cursor: default;
+}

--- a/devtools/frontend/bindings/ResourceUtils.js
+++ b/devtools/frontend/bindings/ResourceUtils.js
@@ -181,7 +181,9 @@ WebInspector.linkifyURLAsNode = function(url, linkText, classes, isExternal, too
     classes = (classes ? classes + " " : "");
     classes += isExternal ? "webkit-html-external-link" : "webkit-html-resource-link";
 
-    var a = document.createElement("a");
+    //strongloop: change to span so links to files are not actual links
+    //since we don't have the actual file to link to
+    var a = document.createElement("span");
     var href = sanitizeHref(url);
     if (href !== null)
         a.href = href;


### PR DESCRIPTION
- the links to files are broken because we don't have a file on the file system to link to
- make them spans instead
- change link styling to look like a span

#1028