### PR TITLE
Fix 959 redux

### DIFF
--- a/client/www/scripts/modules/pm/pm.services.js
+++ b/client/www/scripts/modules/pm/pm.services.js
@@ -133,19 +133,19 @@ PM.service('PMHostService', [
       var PMClient = require('strong-mesh-models').Client;
       var pm = new PMClient('http://' + pmHost.host + ':' + pmHost.port );
 
-      pm.instanceFind('1', function(err, instance) {
-        if (err) {
-          $log.warn('trace: error finding pm instance: ' + err.message);
-          return cb(err, null);
-        }
-        if (!instance){
-          $log.warn('trace: no instance returned: ');
-          return cb({message:'no instance returned'}, null);
-        }
+        pm.instanceFind('1', function(err, instance) {
+          if (err) {
+            $log.warn('trace: error finding pm instance: ' + err.message);
+            return cb(err, null);
+          }
+          if (!instance){
+            $log.warn('trace: no instance returned: http://' + pmHost.host + ':' + pmHost.port );
+            return cb({message:'no instance returned'}, null);
+          }
 
-        return cb(null, instance);
+          return cb(null, instance);
 
-      });
+        });
     };
     svc.getLatestPMServer = function(cb) {
       // get the last entry in the array


### PR DESCRIPTION
Replaces https://github.com/strongloop/strong-arc/pull/1566
Connected to #1565
Connected to strongloop-internal/scrum-nodeops#937

@seanbrookes I didn't want to overwrite your PR, it might mess you up, but I rebased it and rewrote the commit message to reflect current behaviour.

This PR is completely identical to #1566, except for this difference:

```
diff --git a/client/www/scripts/modules/tracing/tracing.controllers.js b/client/www/scripts/modules/tracing/tracing.controllers.js
index b474b21..e9349e5 100644
--- a/client/www/scripts/modules/tracing/tracing.controllers.js
+++ b/client/www/scripts/modules/tracing/tracing.controllers.js
@@ -248,12 +248,12 @@ Tracing.controller('TracingMainController', [
               $log.warn('bad pm reload', err);
               return;
             }
-            var targetProcessCount = instance.setSize;
-            if (targetProcessCount > 0) {
+            $scope.targetProcessCount = instance.setSize;
+            if ($scope.targetProcessCount > 0) {
               $scope.startTicker();
               // processes are still coming up
               var fpLen = filteredProcesses.length;
-              if (fpLen !== targetProcessCount) {
+              if (fpLen !== $scope.targetProcessCount) {
                 if (!restarting) {
                   if (prevTracingPidCount !== fpLen) {
                     // show progress via growl each time the process count changes

```

This fixes a bug where the progress string "X of N process restarted" (or somesuch) has the wrong `N` value if it is changed while the cluster is restarting. It does this by updating the global var to always be as current as possible.

I suggest merging this, and closing #1566.