### PR TITLE
Fix delete then set pid count issue in PM view

### DIFF
--- a/client/www/scripts/modules/manager/templates/manager.process.count.html
+++ b/client/www/scripts/modules/manager/templates/manager.process.count.html
@@ -9,9 +9,8 @@
       class="ui-input"
       placeholder="(eg. 4)"
       min="1"
-      ng-change="updateProcessCount(host)"
+      ng-blur="updateProcessCount(host)"
       ng-model="host.targetProcessCount"
       ng-disabled="host.status.isProblem" />
-    <!--<span>{{ host.processCount }}</span>-->
   </div>
 </ng-form>

--- a/client/www/scripts/modules/manager/templates/manager.process.list.html
+++ b/client/www/scripts/modules/manager/templates/manager.process.list.html
@@ -1,5 +1,11 @@
-<ul class="ui-list-scroll skinny">
-  <li ng-repeat="pid in host.processes.pids">
-    {{ pid.pid }}
-  </li>
-</ul>
+<div>
+  <div class="loading"
+       sl-common-loading-indicator
+       size="small"
+       ng-show="isShowPidsLoadingSpinner(host)"></div>
+  <ul class="ui-list-scroll skinny" ng-show="!isShowPidsLoadingSpinner(host)">
+    <li ng-repeat="pid in host.processes.pids">
+      {{ pid.pid }}
+    </li>
+  </ul>
+</div>


### PR DESCRIPTION
- if user deletes value before setting a new one the app was triggering a reset to 1 and submitting the change request to the backend
- it is now checking for an integer before firing request
- also changed from an onChange to an onBlur event to trigger the update to avoid unintended updates for large number values

connected to: strongloop-internal/scrum-loopback#522