### PR TITLE
use Blob instead of File object in profiler

### DIFF
--- a/client/www/scripts/modules/common/lb-build.js
+++ b/client/www/scripts/modules/common/lb-build.js
@@ -316,7 +316,7 @@ module.factory(
          *   populated with the actual data once the response is returned
          *   from the server.
          *
-         * The number of instances updated
+         * This method returns no data.
          */
         "updateAll": {
           url: urlBase + "/Builds/update",
@@ -346,10 +346,7 @@ module.factory(
          *   populated with the actual data once the response is returned
          *   from the server.
          *
-         * <em>
-         * (The remote method definition does not provide any description.
-         * This usually means the response is a `Build` object.)
-         * </em>
+         * This method returns no data.
          */
         "deleteById": {
           url: urlBase + "/Builds/:id",
@@ -568,7 +565,7 @@ module.factory(
          *   populated with the actual data once the response is returned
          *   from the server.
          *
-         * The number of instances updated
+         * This method returns no data.
          */
         R["update"] = R["updateAll"];
 
@@ -595,10 +592,7 @@ module.factory(
          *   populated with the actual data once the response is returned
          *   from the server.
          *
-         * <em>
-         * (The remote method definition does not provide any description.
-         * This usually means the response is a `Build` object.)
-         * </em>
+         * This method returns no data.
          */
         R["destroyById"] = R["deleteById"];
 
@@ -625,10 +619,7 @@ module.factory(
          *   populated with the actual data once the response is returned
          *   from the server.
          *
-         * <em>
-         * (The remote method definition does not provide any description.
-         * This usually means the response is a `Build` object.)
-         * </em>
+         * This method returns no data.
          */
         R["removeById"] = R["deleteById"];
 

--- a/client/www/scripts/modules/profiler/profiler.services.js
+++ b/client/www/scripts/modules/profiler/profiler.services.js
@@ -94,7 +94,9 @@ Profiler.service('ProfilerService', [
 
             if ( data.status === 200 ) {
               $interval.cancel(intv);
-              var file = new File([data.data], fileName, { type: "text/plain" });
+              //var file = new File([data.data], fileName, { type: "text/plain" });
+              var file = new Blob([data.data], { type: "text/plain" });
+              file.name = fileName;
 
               def.resolve(file);
             } else if ( data.status !== 204 ) {

--- a/client/www/scripts/modules/profiler/profiler.services.js
+++ b/client/www/scripts/modules/profiler/profiler.services.js
@@ -94,7 +94,6 @@ Profiler.service('ProfilerService', [
 
             if ( data.status === 200 ) {
               $interval.cancel(intv);
-              //var file = new File([data.data], fileName, { type: "text/plain" });
               var file = new Blob([data.data], { type: "text/plain" });
               file.name = fileName;
 


### PR DESCRIPTION
- fixes unsupported File constructor in Safari

#851 