### PR TITLE
Add user easing for when chart data is insuffient

### DIFF
--- a/client/less/metrics.less
+++ b/client/less/metrics.less
@@ -174,10 +174,18 @@ ul.metric-timer-list {
   .metrics-chart svg {
     background-color: #ffffff;
   }
+
+  &+.no-chart-info {
+    display: none;
+  }
+}
+.chart-placeholder {
+  text-align: center;
+  margin: 14rem 0;
 }
 .metrics-chart-controls {
   float: right;
-  margin: 2.0rem 0;
+  margin: 0;
 
   li {
     display: inline-block;

--- a/client/www/scripts/modules/metrics/metrics.controllers.js
+++ b/client/www/scripts/modules/metrics/metrics.controllers.js
@@ -29,20 +29,22 @@ Metrics.controller('MetricsMainController', [
     });
 
     $scope.isCollapsed = true;  // settings
+    // the minimum number of datapoints required before rendering a chart
+    $scope.minInitDataPoints = 2;
     $scope.maxInitDataPointThreshold = MetricsService.getMaxInitDataPointThreshold();  // limit on the initial data load
     $scope.maxDataPointThrottle = MetricsService.getMaxDataPointThrottle();  // max number of current data points
     $scope.metricsUpdateInterval = MetricsService.getMetricsUpdateInterval();
     $scope.currentPMServerName = ''; // hybrid host / port as unique id metric branch
-    $scope.currentWorkerId;
-    $scope.currentProcessId;
+    $scope.currentWorkerId = null;
+    $scope.currentProcessId = null;
     $scope.activeProcess = null;
     $scope.isTimerRunning = false;
     $scope.isBackground = false;
     $scope.isMetricsLoaded = false;
     $scope.dataPointCount = 0;
-    $scope.lastGoodTS; // fallback
+    $scope.lastGoodTS = null; // fallback
     $scope.breakLoop = false;
-    $scope.currentStub; // temporary dataset to drive the current context
+    $scope.currentStub = undefined; // temporary dataset to drive the current context
     $scope.lastTimeStamp = {}; // object collection of metrics servers and the last metrics received
     $scope.currentMetrics = []; // the root
     $scope.sysTime = {
@@ -419,6 +421,18 @@ Metrics.controller('MetricsMainController', [
       return $scope[modelRef];
     };
 
+    $scope.showChartLoading = function(modelRef) {
+      var data = $scope[modelRef];
+
+      if (data) {
+        return data.some(function(x) {
+          return x.values && x.values.length < $scope.minInitDataPoints;
+        });
+      }
+
+      return true;
+    };
+
     $scope.showChart = function(chart, modelRef) {
       if ($scope.readyCharts) {
         return true;
@@ -487,14 +501,16 @@ Metrics.controller('MetricsMainController', [
       ChartConfigService.toggleMetricStatus(chartMetric);
       renderTheCharts();
     };
+
     $scope.startTicker = function() {
-      $scope.sysTime.ticker = $scope.metricsUpdateInterval;
       $scope.startTimer();
     };
+
     $scope.restartTicker = function() {
       $scope.sysTime.ticker = $scope.metricsUpdateInterval;
       $scope.startTimer();
     };
+
     $scope.startTimer = function() {
       // cancel the previous interval if it wasn't cleaned up
       $scope.stopTimer();

--- a/client/www/scripts/modules/metrics/templates/metrics.chart.container.html
+++ b/client/www/scripts/modules/metrics/templates/metrics.chart.container.html
@@ -1,20 +1,29 @@
 <div class="metrics-chart-view-container">
   <div ng-repeat="chart in chartData" class="chart-container">
-    <div data-ui-type="table">
-      <div data-ui-type="row">
-        <div data-ui-type="cell" class="main-chart-col" ng-show="showChart(chart, chart.chartModel)">
-          <ul class="metrics-chart-controls">
-            <li ng-repeat="metric in chart.metrics">
-              <label class="" ng-click="toggleChartMetric(metric)">
-                <span class="metrics-series-toggle" style="{{ getChartControlItemColor(metric) }}"></span>
-                <span class="ui-label-txt">{{ metric.key }}</span>
-              </label>
-            </li>
-          </ul>
-          <h3>{{ chart.displayName }}</h3>
-          <nvd3 class="metrics-chart" options="getChartOptions(chart.chartConfig)" data="getChartModel(chart.chartModel)"></nvd3>
+      <div class="main-chart-col" ng-show="showChart(chart, chart.chartModel)">
+        <ul class="metrics-chart-controls">
+          <li ng-repeat="metric in chart.metrics">
+            <label class="" ng-click="toggleChartMetric(metric)">
+              <span class="metrics-series-toggle" style="{{ getChartControlItemColor(metric) }}"></span>
+              <span class="ui-label-txt">{{ metric.key }}</span>
+            </label>
+          </li>
+        </ul>
+        <h3>{{ chart.displayName }}</h3>
+        <div class="chart-placeholder"
+          ng-if="showChartLoading(chart.chartModel)">
+          Collecting Metric Data...
         </div>
-      </div>
+        <nvd3 class="metrics-chart"
+          ng-if="!showChartLoading(chart.chartModel)"
+          options="getChartOptions(chart.chartConfig)"
+          data="getChartModel(chart.chartModel)">
+        </nvd3>
+    </div>
+  </div>
+  <div class="chart-container no-chart-info">
+    <div class="chart-placeholder">
+      Getting Available Metrics...
     </div>
   </div>
 </div>


### PR DESCRIPTION
In metrics, a minimum of 2 datapoint are needed to display the graphs
properly. This change adds in placeholders to improve the UX when the
scope doesn’t have enough data to show the charts properly.

connect to #1513