### PR TITLE
Fix error when overriding host

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -100,7 +100,7 @@ function getLocalIntfAddr(defaultAddr) {
 
     intf.forEach(function(addr) {
       if (addr.family === 'IPv4' && addr.internal === false) {
-        localIntfAddr = alias.address;
+        localIntfAddr = addr.address;
         return false;
       }
     });


### PR DESCRIPTION
Fix and error that prevents Arc from starting when the user overrides
the host to 0.0.0.0.